### PR TITLE
Wait for main-IBD to complete before starting sidechain binary

### DIFF
--- a/packages/sidesail/lib/config/sidechains.dart
+++ b/packages/sidesail/lib/config/sidechains.dart
@@ -107,7 +107,6 @@ extension SidechainPaths on SidechainType {
         // TODO: make this properly configurable
         return 'config.toml';
       case SidechainType.zcash:
-        // TODO: make this properly configurable
         return 'zcash.conf';
     }
   }

--- a/packages/sidesail/lib/rpc/models/blockchain_info.dart
+++ b/packages/sidesail/lib/rpc/models/blockchain_info.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+
+class BlockchainInfo {
+  // indicates whether the chain is currently downloading the chain
+  // for the first time
+  final bool initialBlockDownload;
+
+  BlockchainInfo({
+    required this.initialBlockDownload,
+  });
+
+  factory BlockchainInfo.fromMap(Map<String, dynamic> map) {
+    return BlockchainInfo(
+      initialBlockDownload: map['initialblockdownload'] ?? '',
+    );
+  }
+
+  static BlockchainInfo fromJson(String json) => BlockchainInfo.fromMap(jsonDecode(json));
+  String toJson() => jsonEncode(toMap());
+
+  Map<String, dynamic> toMap() => {
+        'initialblockdownload': initialBlockDownload,
+      };
+}

--- a/packages/sidesail/lib/rpc/rpc.dart
+++ b/packages/sidesail/lib/rpc/rpc.dart
@@ -12,6 +12,8 @@ import 'package:sidesail/app.dart';
 import 'package:sidesail/pages/tabs/settings/node_settings_tab.dart';
 import 'package:sidesail/providers/process_provider.dart';
 
+const ibdWarning = 'Waiting on L1 initial block download to complete';
+
 // when you implement this class, you should extend a ChangeNotifier, to get
 // a proper implementation of notifyListeners(), e.g:
 // YourClass extends ChangeNotifier implements RPCConnection
@@ -49,7 +51,10 @@ abstract class RPCConnection extends ChangeNotifier {
       if (!initializingBinary) {
         String? msg = error.toString();
 
-        if (msg.contains('Connection refused')) {
+        if (connectionError != null && connectionError!.contains(ibdWarning)) {
+          // don't change the message nothing, we're waiting
+          msg = ibdWarning;
+        } else if (msg.contains('Connection refused')) {
           if (connectionError != null) {
             // an error is already set, and we don't want to override it with
             // a generic non-informative message!
@@ -89,7 +94,7 @@ abstract class RPCConnection extends ChangeNotifier {
 
   // values for tracking connection state, and error (if any)
   SingleNodeConnectionSettings conf;
-  String? connectionError;
+  String? connectionError = ibdWarning;
   bool connected = false;
   int blockCount = 0;
 

--- a/packages/sidesail/lib/rpc/rpc_mainchain.dart
+++ b/packages/sidesail/lib/rpc/rpc_mainchain.dart
@@ -4,6 +4,7 @@ import 'package:dart_coin_rpc/dart_coin_rpc.dart';
 import 'package:dio/dio.dart';
 import 'package:sidesail/pages/tabs/settings/node_settings_tab.dart';
 import 'package:sidesail/rpc/models/active_sidechains.dart';
+import 'package:sidesail/rpc/models/blockchain_info.dart';
 import 'package:sidesail/rpc/models/utxo.dart';
 import 'package:sidesail/rpc/rpc.dart';
 
@@ -20,6 +21,7 @@ abstract class MainchainRPC extends RPCConnection {
   Future<List<MainchainWithdrawal>> listSpentWithdrawals();
   Future<List<MainchainWithdrawal>> listFailedWithdrawals();
   Future<List<MainchainWithdrawalStatus>> listWithdrawalStatus(int slot);
+  Future<BlockchainInfo> getBlockchainInfo();
 
   Future<String> send(String address, double amount, bool subtractFeeFromAmount);
   Future<String> getNewAddress();
@@ -186,6 +188,12 @@ class MainchainRPCLive extends MainchainRPC {
     final txid = await _client().call('createsidechaindeposit', [sidechainSlot, address, amount, fee]) as String;
 
     return txid;
+  }
+
+  @override
+  Future<BlockchainInfo> getBlockchainInfo() async {
+    final confirmedFut = await _client().call('getblockchaininfo');
+    return BlockchainInfo.fromMap(confirmedFut);
   }
 }
 

--- a/packages/sidesail/lib/rpc/rpc_zcash.dart
+++ b/packages/sidesail/lib/rpc/rpc_zcash.dart
@@ -49,12 +49,25 @@ Future<void> writeConfFileIfNotExists(Logger log) async {
     await zcashDataDir.create(recursive: true);
   }
 
-  final file = File('${zcashDataDir.path}/zcash.conf');
+  final confFile = ZCashSidechain().type.confFile();
+
+  final file = File('${zcashDataDir.path}/$confFile');
 
   if (!await file.exists()) {
-    log.i('zcash.conf does not exist, creating');
-    // zcash needs an empty conf file to run
+    log.i('$confFile does not exist, creating');
+    // zcash needs conf file to run
     await file.create();
+    // so let's write some default values to it
+    await file.writeAsString('''rpcuser=user
+rpcpassword=password
+server=1
+regtest=1
+addnode=172.105.148.135
+rpcport=8232
+nuparams=76b809bb:1
+nuparams=f5b9230b:5
+walletrequirebackup=false
+''');
   }
 }
 
@@ -75,16 +88,6 @@ abstract class ZCashRPC extends SidechainRPC {
 
     addEntryIfNotSet(args, 'mainport', mainchainConf.port.toString());
     addEntryIfNotSet(args, 'mainhost', mainchainConf.host);
-
-    addEntryIfNotSet(args, 'walletrequirebackup', 'false');
-
-    const l2PublicRegtestPeer = '172.105.148.135';
-    addEntryIfNotSet(args, 'addnode', l2PublicRegtestPeer);
-    addEntryIfNotSet(args, 'server', '1');
-    addEntryIfNotSet(args, 'regtest', '1');
-
-    args.add('-nuparams=76b809bb:1'); // activate overwinter at block height 1
-    args.add('-nuparams=f5b9230b:5'); // activate heartwood at block height 5
 
     return args;
   }

--- a/packages/sidesail/test/mocks/rpc_mock_mainchain.dart
+++ b/packages/sidesail/test/mocks/rpc_mock_mainchain.dart
@@ -1,5 +1,6 @@
 import 'package:sidesail/pages/tabs/settings/node_settings_tab.dart';
 import 'package:sidesail/rpc/models/active_sidechains.dart';
+import 'package:sidesail/rpc/models/blockchain_info.dart';
 import 'package:sidesail/rpc/models/utxo.dart';
 import 'package:sidesail/rpc/rpc_mainchain.dart';
 
@@ -92,5 +93,10 @@ class MockMainchainRPC extends MainchainRPC {
   @override
   Future<String> createSidechainDeposit(int sidechainSlot, String address, double amount) async {
     return 'txiddeadbeef';
+  }
+
+  @override
+  Future<BlockchainInfo> getBlockchainInfo() async {
+    return BlockchainInfo(initialBlockDownload: false);
   }
 }


### PR DESCRIPTION
Issues can occur when starting the sidechain binaries before the mainchain has completed its initial block download. In this PR, we don't start any sidechain binary until IBD is complete, and the mainchain is fully synced. That way, we can be confident all sidechains are activated correctly, and misc other things that's needed to start things gracefully.

It also moves all zcash-configuration to zcash.conf, nothing in the code itself, by writing default values to zcash.conf if it does not exist at startup.