### PR TITLE
withdrawal bundle in separate tab

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -44,8 +44,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         chain: [testchain, ethereum, zcash]
+        exclude:
+          - os: windows-latest
+            chain: zcash
 
     name: Build binaries
     runs-on: ${{ matrix.os }}
@@ -147,12 +150,14 @@ jobs:
           # The files here are already zips. No point in zipping again!
           run: |
             mv sidesail-binaries-macOS-testchain/testsail-osx64.zip L2-S0-TestSail-latest-x86_64-apple-darwin.zip 
+            mv sidesail-binaries-Windows-testchain/testsail-win64.zip L2-S0-TestSail-latest-x86_64-w64-mingw32.zip 
             mv sidesail-binaries-Linux-testchain/testsail-x86_64-linux-gnu.zip L2-S0-TestSail-latest-x86_64-unknown-linux-gnu.zip 
 
             mv sidesail-binaries-macOS-zcash/zsail-osx64.zip L2-S5-ZSail-latest-x86_64-apple-darwin.zip 
             mv sidesail-binaries-Linux-zcash/zsail-x86_64-linux-gnu.zip L2-S5-ZSail-latest-x86_64-unknown-linux-gnu.zip 
 
             mv sidesail-binaries-macOS-ethereum/ethsail-osx64.zip L2-S6-EthSail-latest-x86_64-apple-darwin.zip 
+            mv sidesail-binaries-Windows-ethereum/ethsail-win64.zip L2-S6-EthSail-latest-x86_64-w64-mingw32.zip 
             mv sidesail-binaries-Linux-ethereum/ethsail-x86_64-linux-gnu.zip L2-S6-EthSail-latest-x86_64-unknown-linux-gnu.zip 
 
         - name: Upload artifacts to releases.drivechain.info

--- a/packages/sidesail/lib/pages/tabs/home_page.dart
+++ b/packages/sidesail/lib/pages/tabs/home_page.dart
@@ -20,7 +20,7 @@ enum Tabs {
   SidechainExplorer,
 
   ParentChainPeg,
-  ParentChainTransfer,
+  ParentChainWithdrawalExplorer,
   ParentChainBMM,
 
   SidechainSend,
@@ -85,7 +85,7 @@ class _HomePageState extends State<HomePage> {
 
       // parent chain routes
       DepositWithdrawTabRoute(),
-      TransferMainchainTabRoute(),
+      WithdrawalExplorerTabRoute(),
       BlindMergedMiningTabRoute(),
 
       // testchain routes

--- a/packages/sidesail/lib/pages/tabs/testchain/mainchain/deposit_withdraw_tab_route.dart
+++ b/packages/sidesail/lib/pages/tabs/testchain/mainchain/deposit_withdraw_tab_route.dart
@@ -67,10 +67,6 @@ class DepositWithdrawTabPage extends StatelessWidget {
                             ),
                         ],
                       ),
-                      const DashboardGroup(
-                        title: 'Withdrawal Explorer',
-                        children: [WithdrawalExplorer()],
-                      ),
                     ],
                   ),
                 ],

--- a/packages/sidesail/lib/pages/tabs/testchain/mainchain/withdrawal_explorer.dart
+++ b/packages/sidesail/lib/pages/tabs/testchain/mainchain/withdrawal_explorer.dart
@@ -1,1 +1,243 @@
+import 'dart:async';
 
+import 'package:auto_route/auto_route.dart';
+import 'package:collection/collection.dart';
+import 'package:dart_coin_rpc/dart_coin_rpc.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:sail_ui/widgets/core/sail_text.dart';
+import 'package:sail_ui/widgets/loading_indicator.dart';
+import 'package:sidesail/rpc/rpc_mainchain.dart';
+import 'package:sidesail/rpc/rpc_testchain.dart';
+import 'package:sidesail/rpc/rpc_withdrawal_bundle.dart';
+import 'package:sidesail/widgets/containers/tabs/dashboard_tab_widgets.dart';
+import 'package:sidesail/widgets/containers/tabs/deposit_withdraw_tab_widgets.dart';
+import 'package:stacked/stacked.dart';
+
+@RoutePage()
+class WithdrawalExplorerTabPage extends StatelessWidget {
+  const WithdrawalExplorerTabPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder.reactive(
+      viewModelBuilder: () => WithdrawalBundleTabPageViewModel(),
+      builder: ((context, viewModel, child) {
+        return SailPage(
+          body: SingleChildScrollView(
+            child: Column(
+              children: [
+                SailRow(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: SailStyleValues.padding10,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: SailStyleValues.padding30,
+                        vertical: SailStyleValues.padding15,
+                      ),
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 600),
+                        child: SailTextField(
+                          controller: viewModel.searchController,
+                          prefixIcon: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: SailStyleValues.padding05),
+                            child: SailSVG.icon(SailSVGAsset.iconSearch),
+                          ),
+                          prefixIconConstraints: const BoxConstraints(maxHeight: 20),
+                          hintText: 'Search for TXID',
+                        ),
+                      ),
+                    ),
+                    // eat up the rest of the space by adding an empty expanded
+                    Expanded(
+                      child: Container(),
+                    ),
+                  ],
+                ),
+                DashboardGroup(
+                  title: 'Unbundled transactions',
+                  widgetTrailing: SailText.secondary13('${viewModel.unbundledTransactions.length}'),
+                  children: [
+                    SailColumn(
+                      spacing: 0,
+                      withDivider: true,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children:
+                          (viewModel.unbundledTransactions).map((e) => UnbundledWithdrawalView(withdrawal: e)).toList(),
+                    ),
+                  ],
+                ),
+                const SailSpacing(SailStyleValues.padding30),
+                DashboardGroup(
+                  title: 'Bundle history',
+                  widgetTrailing: SailText.secondary13('${viewModel.bundles.length} bundle(s)'),
+                  children: [
+                    SailColumn(
+                      spacing: 0,
+                      withDivider: true,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ...[
+                          if (!viewModel.hasDoneInitialFetch) LoadingIndicator.overlay(),
+                          if (viewModel.bundleCount == 0)
+                            Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(SailStyleValues.padding30),
+                                child: SailText.primary20('No withdrawal bundle'),
+                              ),
+                            ),
+                        ],
+                        ...viewModel.bundles.map(
+                          (bundle) => BundleView(
+                            bundle: bundle,
+                            timesOutIn: viewModel.timesOutIn(bundle.hash),
+                            votes: viewModel.votes(bundle.hash),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class WithdrawalBundleTabPageViewModel extends BaseViewModel {
+  TestchainRPC get _sidechain => GetIt.I.get<TestchainRPC>();
+  MainchainRPC get _mainchain => GetIt.I.get<MainchainRPC>();
+
+  final searchController = TextEditingController();
+
+  WithdrawalBundleTabPageViewModel() {
+    _startWithdrawalBundleFetch();
+  }
+
+  Timer? _withdrawalBundleTimer;
+
+  bool hasDoneInitialFetch = false;
+
+  WithdrawalBundle? currentBundle;
+  int? votesCurrentBundle;
+
+  List<MainchainWithdrawalStatus> statuses = [];
+  List<WithdrawalBundle> successfulBundles = [];
+  List<WithdrawalBundle> failedBundles = [];
+
+  int get bundleCount => successfulBundles.length + failedBundles.length + (currentBundle != null ? 1 : 0);
+  Iterable<WithdrawalBundle> get bundles => [
+        if (currentBundle != null) currentBundle!,
+        ...successfulBundles,
+        ...failedBundles,
+      ]
+          .where((element) => searchController.text == '' || element.hash.contains(searchController.text))
+          .sortedByCompare(
+            (
+              b1,
+            ) =>
+                b1.blockHeight,
+            (a, b) => a.compareTo(b),
+          )
+          .reversed; // we want the newest first!
+
+  List<Withdrawal> _unbundledTransactions = [];
+  Iterable<Withdrawal> get unbundledTransactions => _unbundledTransactions
+      .where((element) => searchController.text == '' || element.hashBlindTx.contains(searchController.text));
+
+  int votes(String hash) {
+    bool byHash(WithdrawalBundle bundle) => bundle.hash == hash;
+
+    if (successfulBundles.firstWhereOrNull(byHash) != null) {
+      return bundleVotesRequired;
+    }
+
+    if (failedBundles.firstWhereOrNull(byHash) != null) {
+      return 0;
+    }
+
+    if (hash == currentBundle?.hash) {
+      return votesCurrentBundle ?? 0;
+    }
+
+    // TODO; return 0 zero here?
+    throw 'received hash for unknown bundle: $hash';
+  }
+
+  /// Block count until a bundle times out
+  int timesOutIn(String hash) {
+    final stat = statuses.firstWhereOrNull((element) => element.hash == hash);
+    return stat?.blocksLeft ?? 0;
+  }
+
+  void _fetchWithdrawalBundle() async {
+    try {
+      final statusesFut = _mainchain.listWithdrawalStatus(_sidechain.chain.slot);
+      final currentFut = _sidechain.mainCurrentWithdrawalBundle();
+      final rawSuccessfulBundlesFut = _mainchain.listSpentWithdrawals();
+      final rawFailedBundlesFut = _mainchain.listFailedWithdrawals();
+      final nextFut = _sidechain.mainNextWithdrawalBundle();
+
+      statuses = await statusesFut;
+      final rawSuccessfulBundles = await rawSuccessfulBundlesFut;
+      final rawFailedBundles = await rawFailedBundlesFut;
+
+      bool removeOtherChains(MainchainWithdrawal w) => w.sidechain == _sidechain.chain.slot;
+      Future<WithdrawalBundle> Function(MainchainWithdrawal w) getBundle(BundleStatus status) =>
+          (MainchainWithdrawal w) => _sidechain.lookupWithdrawalBundle(w.hash, status);
+
+      // Cooky town: passing in a status parameter to this...
+      final successfulBundlesFut = Future.wait(
+        rawSuccessfulBundles.where(removeOtherChains).map(getBundle(BundleStatus.success)),
+      );
+
+      final failedBundlesFut = Future.wait(
+        rawFailedBundles.where(removeOtherChains).map(getBundle(BundleStatus.failed)),
+      );
+
+      successfulBundles = await successfulBundlesFut;
+      failedBundles = await failedBundlesFut;
+
+      currentBundle = await currentFut.then((bundle) {
+        // `testchain-cli getwithdrawalbundle` continues to return the most recent bundle, also
+        // after it shows up in `drivechain-cli listspentwithdrawals/listfailedwithdrawals`.
+        // Filter that out, so it doesn't show up twice.
+        final allBundles = [...successfulBundles, ...failedBundles];
+        if (allBundles.firstWhereOrNull((success) => success.hash == (bundle?.hash ?? '')) != null) {
+          return null;
+        }
+        return bundle;
+      });
+
+      if (currentBundle != null) {
+        votesCurrentBundle = await _mainchain.getWithdrawalBundleWorkScore(_sidechain.chain.slot, currentBundle!.hash);
+      }
+
+      _unbundledTransactions = (await nextFut).withdrawals;
+    } on RPCException catch (err) {
+      if (err.errorCode != TestchainRPCError.errNoWithdrawalBundle) {
+        rethrow;
+      }
+    } finally {
+      hasDoneInitialFetch = true;
+      notifyListeners();
+    }
+  }
+
+  void _startWithdrawalBundleFetch() {
+    _withdrawalBundleTimer = Timer.periodic(const Duration(seconds: 1), (timer) async {
+      _fetchWithdrawalBundle();
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _withdrawalBundleTimer?.cancel();
+  }
+}

--- a/packages/sidesail/lib/routing/router.dart
+++ b/packages/sidesail/lib/routing/router.dart
@@ -10,6 +10,7 @@ import 'package:sidesail/pages/tabs/sidechain_send_page.dart';
 import 'package:sidesail/pages/tabs/testchain/mainchain/bmm_tab_page.dart';
 import 'package:sidesail/pages/tabs/testchain/mainchain/deposit_withdraw_tab_route.dart';
 import 'package:sidesail/pages/tabs/testchain/mainchain/transfer_mainchain_tab_route.dart';
+import 'package:sidesail/pages/tabs/testchain/mainchain/withdrawal_explorer.dart';
 import 'package:sidesail/pages/tabs/testchain/testchain_rpc_tab_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_bill_page.dart';
 import 'package:sidesail/pages/tabs/zcash/zcash_melt_cast_page.dart';
@@ -52,7 +53,7 @@ class AppRouter extends _$AppRouter {
               page: DepositWithdrawTabRoute.page,
             ),
             AutoRoute(
-              page: TransferMainchainTabRoute.page,
+              page: WithdrawalExplorerTabRoute.page,
             ),
             AutoRoute(
               page: BlindMergedMiningTabRoute.page,

--- a/packages/sidesail/lib/routing/router.gr.dart
+++ b/packages/sidesail/lib/routing/router.gr.dart
@@ -79,6 +79,12 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const TransferMainchainTabPage(),
       );
     },
+    WithdrawalExplorerTabRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const WithdrawalExplorerTabPage(),
+      );
+    },
     ZCashBillRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -192,7 +198,8 @@ class SailTestRoute extends PageRouteInfo<SailTestRouteArgs> {
 
   static const String name = 'SailTestRoute';
 
-  static const PageInfo<SailTestRouteArgs> page = PageInfo<SailTestRouteArgs>(name);
+  static const PageInfo<SailTestRouteArgs> page =
+      PageInfo<SailTestRouteArgs>(name);
 }
 
 class SailTestRouteArgs {
@@ -277,6 +284,20 @@ class TransferMainchainTabRoute extends PageRouteInfo<void> {
         );
 
   static const String name = 'TransferMainchainTabRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [WithdrawalExplorerTabPage]
+class WithdrawalExplorerTabRoute extends PageRouteInfo<void> {
+  const WithdrawalExplorerTabRoute({List<PageRouteInfo>? children})
+      : super(
+          WithdrawalExplorerTabRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'WithdrawalExplorerTabRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }

--- a/packages/sidesail/lib/widgets/containers/tabs/home/top_nav.dart
+++ b/packages/sidesail/lib/widgets/containers/tabs/home/top_nav.dart
@@ -77,13 +77,14 @@ class _TopNavState extends State<TopNav> {
                               tabsRouter.setActiveIndex(Tabs.ParentChainPeg.index);
                             },
                           ),
-                          NavEntry(
-                            title: 'Send',
-                            selected: tabsRouter.activeIndex == Tabs.ParentChainTransfer.index,
-                            onPressed: () {
-                              tabsRouter.setActiveIndex(Tabs.ParentChainTransfer.index);
-                            },
-                          ),
+                          if (_sidechain.rpc.chain.type == SidechainType.testChain)
+                            NavEntry(
+                              title: 'Withdrawal Explorer',
+                              selected: tabsRouter.activeIndex == Tabs.ParentChainWithdrawalExplorer.index,
+                              onPressed: () {
+                                tabsRouter.setActiveIndex(Tabs.ParentChainWithdrawalExplorer.index);
+                              },
+                            ),
                           if (_sidechain.rpc.chain.type == SidechainType.testChain)
                             NavEntry(
                               title: 'Blind Merged Mining',


### PR DESCRIPTION
- **pubspec: bump em, and bump em all**
- **delete testchaind from git**
- **rpc/mainchain: move ibd check inside mainchain rpc**
- **tabs/multi: rename send RPC to console**
- **tabs/testchain: make slight changes to withdrawal bundle**
- **config/sidechains: update dir paths for testchain**
- **tabs: replace side nav with only top nav**
- **sail_ui/core: set correct blend mode on svgs**
- **tabs/bmm: make page scrollable**
- **tabs/withdrawal/explorer: move explorer to deposit/withdraw page**
- **ci: dont build windows**
- **ci: reenable windows**
- **tabs/testchain: move withdrawal explorer to separate tab**
