### PR TITLE
less agressive rpcing

### DIFF
--- a/packages/sidesail/lib/providers/bmm_provider.dart
+++ b/packages/sidesail/lib/providers/bmm_provider.dart
@@ -19,7 +19,7 @@ class BMMProvider extends ChangeNotifier {
   // https://github.com/LayerTwo-Labs/testchain/blob/c44e3a737d1780a1a07135657ac0fd7686251933/src/qt/sidechainpage.cpp#L767
   void handleBmmTick(int bidAmountSats) async {
     final res = await _rpc.refreshBMM(bidAmountSats);
-    final currentBlockCount = await _rpc.fetchBlockCount();
+    final currentBlockCount = await _rpc.getBlockCount();
 
     if (res.error != null) {
       log.d('was not able to advance BMM: ${res.error}');

--- a/packages/sidesail/lib/rpc/rpc.dart
+++ b/packages/sidesail/lib/rpc/rpc.dart
@@ -26,13 +26,13 @@ abstract class RPCConnection extends ChangeNotifier {
 
   // gets the current block height for this node
   // also used to test the connection
-  Future<int> fetchBlockCount();
+  Future<int> getBlockCount();
 
   bool initializingBinary = false;
 
   Future<(bool, String?)> testConnection() async {
     try {
-      final newBlockCount = await fetchBlockCount();
+      final newBlockCount = await getBlockCount();
       connectionError = null;
       connected = true;
 

--- a/packages/sidesail/lib/rpc/rpc_ethereum.dart
+++ b/packages/sidesail/lib/rpc/rpc_ethereum.dart
@@ -155,7 +155,7 @@ class EthereumRPCLive extends EthereumRPC {
   }
 
   @override
-  Future<int> fetchBlockCount() async {
+  Future<int> getBlockCount() async {
     final blockCount = await callRAW('eth_blockNumber');
     return _fromHex(blockCount);
   }

--- a/packages/sidesail/lib/rpc/rpc_mainchain.dart
+++ b/packages/sidesail/lib/rpc/rpc_mainchain.dart
@@ -183,7 +183,7 @@ class MainchainRPCLive extends MainchainRPC {
   }
 
   @override
-  Future<int> fetchBlockCount() async {
+  Future<int> getBlockCount() async {
     final blockHeight = await _client().call('getblockcount') as int;
     return blockHeight;
   }

--- a/packages/sidesail/lib/rpc/rpc_mainchain.dart
+++ b/packages/sidesail/lib/rpc/rpc_mainchain.dart
@@ -63,7 +63,6 @@ class MainchainRPCLive extends MainchainRPC {
 
   Future<void> init() async {
     await testConnection();
-    startConnectionTimer();
     pollIBDStatus();
   }
 

--- a/packages/sidesail/lib/rpc/rpc_sidechain.dart
+++ b/packages/sidesail/lib/rpc/rpc_sidechain.dart
@@ -58,20 +58,9 @@ class SidechainContainer extends ChangeNotifier {
 
   Future<void> init() async {
     await _rpc.testConnection();
-    startConnectionTimer();
 
     // assigning here calls the set-method, adding listeners
     rpc = _rpc;
-  }
-
-  // responsible for pinging the currently selected rpc every x seconds
-  // we want to update the UI immediately when the connection drops/begins
-  Timer? _connectionTimer;
-  void startConnectionTimer() {
-    _connectionTimer?.cancel();
-    _connectionTimer = Timer.periodic(const Duration(seconds: 1), (timer) async {
-      await _rpc.testConnection();
-    });
   }
 
   SidechainRPC get rpc => _rpc;

--- a/packages/sidesail/lib/rpc/rpc_testchain.dart
+++ b/packages/sidesail/lib/rpc/rpc_testchain.dart
@@ -173,7 +173,7 @@ class TestchainRPCLive extends TestchainRPC {
   }
 
   @override
-  Future<int> fetchBlockCount() async {
+  Future<int> getBlockCount() async {
     final blockHeight = await _client().call('getblockcount') as int;
     return blockHeight;
   }

--- a/packages/sidesail/lib/rpc/rpc_zcash.dart
+++ b/packages/sidesail/lib/rpc/rpc_zcash.dart
@@ -475,7 +475,7 @@ final zcashRPCMethods = [
   'getaddresstxids',
   'getaddressutxos',
 
-// blockchain methods
+  // blockchain methods
   'getbestblockhash',
   'getblock',
   'getblockchaininfo',
@@ -496,7 +496,7 @@ final zcashRPCMethods = [
   'verifytxoutproof',
   'z_gettreestate',
 
-// control methods
+  // control methods
   'getexperimentalfeatures',
   'getinfo',
   'getmemoryinfo',
@@ -504,11 +504,11 @@ final zcashRPCMethods = [
   'setlogfilter',
   'stop',
 
-// disclosure methods
+  // disclosure methods
   'z_getpaymentdisclosure',
   'z_validatepaymentdisclosure',
 
-// generating methods
+  // generating methods
   'generate',
   'getgenerate',
   'setgenerate',
@@ -538,7 +538,7 @@ final zcashRPCMethods = [
   'ping',
   'setban',
 
-// raw TXs
+  // raw TXs
   'createrawtransaction',
   'decoderawtransaction',
   'decodescript',
@@ -547,7 +547,7 @@ final zcashRPCMethods = [
   'sendrawtransaction',
   'signrawtransaction',
 
-// util methods
+  // util methods
   'createmultisig',
   'estimatefee',
   'estimatepriority',
@@ -555,7 +555,7 @@ final zcashRPCMethods = [
   'verifymessage',
   'z_validateaddress',
 
-// wallet methods
+  // wallet methods
   'addmultisigaddress',
   'backupwallet',
   'deposit',
@@ -619,8 +619,8 @@ final zcashRPCMethods = [
   'z_shieldcoinbase',
   'z_viewtransaction',
   'zcbenchmark',
-  'zcrawjoinsplit' // deprecated,
-      'zcrawkeygen', // deprecated
+  'zcrawjoinsplit', // deprecated,
+  'zcrawkeygen', // deprecated
   'zcrawreceive', // deprecated
   'zcsamplejoinsplit',
 ];

--- a/packages/sidesail/lib/rpc/rpc_zcash.dart
+++ b/packages/sidesail/lib/rpc/rpc_zcash.dart
@@ -396,7 +396,7 @@ class ZcashRPCLive extends ZCashRPC {
   }
 
   @override
-  Future<int> fetchBlockCount() async {
+  Future<int> getBlockCount() async {
     // the network keeps gettin fooked in regtest, adding the remote node
     // as a bad peer. We don't want that, so we try to clear banned every time
     // the block count is refetched

--- a/packages/sidesail/lib/widgets/containers/tabs/home/bottom_nav.dart
+++ b/packages/sidesail/lib/widgets/containers/tabs/home/bottom_nav.dart
@@ -187,7 +187,7 @@ class _NodeConnectionStatus extends ViewModelWidget<BottomNavViewModel> {
     return SailRow(
       spacing: SailStyleValues.padding08,
       children: [
-        if (viewModel.sidechainConnected || viewModel.sidechainInitializing)
+        if (viewModel.sidechainConnected || viewModel.sidechainInitializing || viewModel.inIBD)
           ConnectionStatusChip(
             chain: _sidechain.rpc.chain.name,
             initializing: viewModel.sidechainInitializing,

--- a/packages/sidesail/pubspec.lock
+++ b/packages/sidesail/pubspec.lock
@@ -213,8 +213,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "22993070e17fb5b4eb6315c1229ce7ebc5a3b5ba"
-      resolved-ref: "22993070e17fb5b4eb6315c1229ce7ebc5a3b5ba"
+      ref: ab0b7cb2de6e1634a6e65892770ed0d157d38443
+      resolved-ref: ab0b7cb2de6e1634a6e65892770ed0d157d38443
       url: "https://github.com/barebitcoin/dart_coin_rpc.git"
     source: git
     version: "2.1.7"

--- a/packages/sidesail/pubspec.yaml
+++ b/packages/sidesail/pubspec.yaml
@@ -1,47 +1,25 @@
 name: sidesail
 description: UI for Drivechain (BIP300/301) based sidechains
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
 version: 1.0.0+1
 
 environment:
   sdk: ^3.0.0
   flutter: ^3.13.9
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
   sail_ui:
     path: ../sail_ui
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   dart_coin_rpc:
     git:
       url: https://github.com/barebitcoin/dart_coin_rpc.git
-      # master, as of 15.05.2024
-      ref: 22993070e17fb5b4eb6315c1229ce7ebc5a3b5ba
+      # master, as of 08.06.2024
+      ref: ab0b7cb2de6e1634a6e65892770ed0d157d38443
   flutter_highlighter: ^0.1.1
   logger: ^2.2.0
   dio: ^5.4.3
@@ -69,24 +47,12 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^4.0.0
   auto_route_generator: ^8.0.0
   build_runner: 2.4.10
   msix: ^3.16.7
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
 
   assets:

--- a/packages/sidesail/test/dashboard_test.dart
+++ b/packages/sidesail/test/dashboard_test.dart
@@ -23,8 +23,17 @@ import 'test_utils.dart';
 final txProvider = TransactionsProvider();
 
 void main() {
+  // there's timers in sidechainrpc and mainchainrpc, that
+  // will get shut off when they're disposed. However, they're
+  // not disposed per test!
+  TestWidgetsFlutterBinding.ensureInitialized({
+    'flutter.test.automatic_wait_for_timers': 'false',
+  });
+
   setUpAll(() async {
-    final sidechain = await SidechainContainer.create(MockSidechainRPC());
+    final sidechainRPC = MockSidechainRPC();
+    final sidechain = await SidechainContainer.create(sidechainRPC);
+    GetIt.I.registerLazySingleton<SidechainRPC>(() => sidechainRPC);
     GetIt.I.registerLazySingleton<SidechainContainer>(() => sidechain);
     GetIt.I.registerLazySingleton<MainchainRPC>(() => MockMainchainRPC());
     GetIt.I.registerLazySingleton<ProcessProvider>(() => ProcessProvider());
@@ -37,6 +46,7 @@ void main() {
     // don't start test until balance is fetched
     await balanceProvider.fetch();
   });
+
   testWidgets('can render and show balance', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpSailPage(

--- a/packages/sidesail/test/mocks/rpc_mock_mainchain.dart
+++ b/packages/sidesail/test/mocks/rpc_mock_mainchain.dart
@@ -71,7 +71,7 @@ class MockMainchainRPC extends MainchainRPC {
   }
 
   @override
-  Future<int> fetchBlockCount() async {
+  Future<int> getBlockCount() async {
     return 69;
   }
 

--- a/packages/sidesail/test/mocks/rpc_mock_sidechain.dart
+++ b/packages/sidesail/test/mocks/rpc_mock_sidechain.dart
@@ -53,7 +53,7 @@ class MockSidechainRPC extends SidechainRPC {
   }
 
   @override
-  Future<int> fetchBlockCount() async {
+  Future<int> getBlockCount() async {
     return 69;
   }
 

--- a/packages/sidesail/test/mocks/rpc_mock_zcash.dart
+++ b/packages/sidesail/test/mocks/rpc_mock_zcash.dart
@@ -278,7 +278,7 @@ class MockZCashRPC extends ZCashRPC {
   }
 
   @override
-  Future<int> fetchBlockCount() async {
+  Future<int> getBlockCount() async {
     return 100;
   }
 


### PR DESCRIPTION
Prior to this PR, we were very aggressive in fetching the block count. During startup, as fast as we could. After startup, ~3 block count fetchers were started, when only one was needed. That in turn, lead to "work queue depth exceeded".

After this PR, we only start one connection timer per chain. One for mainchain, another for sidechain. Also remove the super-aggressive startup-fetcher. In sum, we are much nicer to the node.