### PR TITLE
drivechain_client: add necessary macOS entitlements

### DIFF
--- a/packages/drivechain_client/macos/Runner/DebugProfile.entitlements
+++ b/packages/drivechain_client/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/packages/drivechain_client/macos/Runner/Release.entitlements
+++ b/packages/drivechain_client/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Xcode defaults to no outgoing connections for all profiles, this just toggles the app to make HTTP connections as a client.