### PR TITLE
drivechain_client: use typed environment variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,106 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "drivechain_client",
+            "cwd": "packages/drivechain_client",
+            "request": "launch",
+            "type": "dart",
+            "toolArgs": [
+                "--dart-define",
+                "DRIVECHAIN_HOST=localhost",
+                "--dart-define",
+                "DRIVECHAIN_PORT=8080"
+            ]
+        },
+        {
+            "name": "drivechain_client (profile mode)",
+            "cwd": "packages/drivechain_client",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile",
+            "toolArgs": [
+                "--dart-define",
+                "DRIVECHAIN_HOST=localhost",
+                "--dart-define",
+                "DRIVECHAIN_PORT=8080"
+            ]
+        },
+        {
+            "name": "drivechain_client (release mode)",
+            "cwd": "packages/drivechain_client",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release",
+            "toolArgs": [
+                "--dart-define",
+                "DRIVECHAIN_HOST=localhost",
+                "--dart-define",
+                "DRIVECHAIN_PORT=8080"
+            ]
+        },
+        {
+            "name": "faucet",
+            "cwd": "packages/faucet",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "faucet (profile mode)",
+            "cwd": "packages/faucet",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "faucet (release mode)",
+            "cwd": "packages/faucet",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "sail_ui",
+            "cwd": "packages/sail_ui",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "sail_ui (profile mode)",
+            "cwd": "packages/sail_ui",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "sail_ui (release mode)",
+            "cwd": "packages/sail_ui",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "sidesail",
+            "cwd": "packages/sidesail",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "sidesail (profile mode)",
+            "cwd": "packages/sidesail",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "sidesail (release mode)",
+            "cwd": "packages/sidesail",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/packages/drivechain_client/README.md
+++ b/packages/drivechain_client/README.md
@@ -8,11 +8,13 @@ To get the app(s) up and running, make sure you have the following dependencies:
 
 * The [Flutter SDK](https://flutter.dev)
 * An instance of [drivechain-server](../../drivechain-server) running
-* The `DRIVECHAIN_SERVER_URL` environment variable pointing to the above instance
+* The `DRIVECHAIN_HOST` and `DRIVECHAIN_PORT` environment variable pointing to the above instance
 * A BIP 300/301 enabled node running
 
 Running the app is as simple as the following command:
 
 ```bash
-flutter run --dart-define DRIVECHAIN_SERVER_URL=$DRIVECHAIN_SERVER_URL
+flutter run --dart-define DRIVECHAIN_HOST=http://localhost --dart-define DRIVECHAIN_PORT=8080
 ```
+
+The project is set up with launch configurations for Visual Studio Code as well.

--- a/packages/drivechain_client/lib/env.dart
+++ b/packages/drivechain_client/lib/env.dart
@@ -1,0 +1,42 @@
+import 'package:meta/meta.dart';
+
+@immutable
+class Variable<T> {
+  final String key;
+  final T value;
+
+  const Variable(this.key, this.value);
+}
+
+class Environment {
+  // Define the environment variables here
+  static const drivechainHost = Variable(
+    'DRIVECHAIN_HOST',
+    String.fromEnvironment("DRIVECHAIN_HOST", defaultValue: "localhost"),
+  );
+  static const drivechainPort = Variable(
+    'DRIVECHAIN_PORT',
+    int.fromEnvironment("DRIVECHAIN_PORT", defaultValue: 8080),
+  );
+
+  const Environment._();
+
+  static T _validate<T>(Variable v, [bool Function(T)? validator]) {
+    if (v.value == null) {
+      throw StateError('Missing required environment variable: ${v.key}');
+    }
+    if (validator != null && !validator(v.value)) {
+      throw StateError('Invalid value for environment variable: ${v.key}');
+    }
+    return v.value;
+  }
+
+  static void validateAtRuntime() {
+    _validate<String>(drivechainHost, (v) => v.isNotEmpty);
+    _validate<int>(drivechainPort, (v) => v > 0 && v < 65536);
+    // Add more validations for other variables if needed
+  }
+}
+
+// Helper function to access environment variables
+T env<T>(Variable<T> variable) => variable.value;

--- a/packages/drivechain_client/lib/main.dart
+++ b/packages/drivechain_client/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:drivechain_client/env.dart';
 import 'package:drivechain_client/routing/router.dart';
 import 'package:drivechain_client/service.dart';
 import 'package:flutter/material.dart';
@@ -9,6 +10,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
  main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  Environment.validateAtRuntime();
   
   final log = Logger();
   final router = AppRouter();

--- a/packages/drivechain_client/pubspec.lock
+++ b/packages/drivechain_client/pubspec.lock
@@ -510,7 +510,7 @@ packages:
     source: hosted
     version: "0.11.1"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
@@ -630,7 +630,7 @@ packages:
     source: hosted
     version: "1.5.1"
   protobuf:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: protobuf
       sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"

--- a/packages/drivechain_client/pubspec.yaml
+++ b/packages/drivechain_client/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   fixnum: ^1.1.0
   shared_preferences: ^2.3.2
   get_it: ^7.7.0
+  meta: ^1.15.0
+  protobuf: ^3.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Adds a `env.dart` file where all environment config will reside. This adds typed variables and allows for custom variable validation at runtime; useful to weed out config issues before they lead to seemingly unrelated errors. Also adds a launch.json file for Visual Studio Code if useful. If it clutters up the repo without providing real value we can just remove it.