### PR TITLE
sail_ui: make `initMethod` optional

### DIFF
--- a/packages/drivechain_client/lib/main.dart
+++ b/packages/drivechain_client/lib/main.dart
@@ -45,7 +45,6 @@ main() async {
             ),
           );
         },
-        initMethod: (_) => Future.value(),
         accentColor: const Color(0xff000000),
         log: log,
       ),

--- a/packages/faucet/lib/main.dart
+++ b/packages/faucet/lib/main.dart
@@ -22,7 +22,7 @@ Future<void> start() async {
   runApp(
     SailApp(
       // the initial route is defined in routing/router.dart
-      builder: (context) => MaterialApp(
+      builder: (_) => MaterialApp(
         title: 'Drivechain Faucet',
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
@@ -30,10 +30,7 @@ Future<void> start() async {
         ),
         debugShowCheckedModeBanner: false,
         home: const FaucetPage(title: 'Drivechain Faucet'),
-      ),
-      initMethod: (context) async {
-        // no init required
-      },
+      ),      
       accentColor: SailColorScheme.orange,
       log: log,
     ),

--- a/packages/sail_ui/lib/sail_app.dart
+++ b/packages/sail_ui/lib/sail_app.dart
@@ -12,17 +12,17 @@ import 'package:sail_ui/theme/theme_data.dart';
 class SailApp extends StatefulWidget {
   // This key is used to programmatically trigger a rebuild of the widget.
   static GlobalKey<SailAppState> sailAppKey = GlobalKey();
-  final Future<void> Function(BuildContext context) initMethod;
+  final Future<void> Function(BuildContext context)? initMethod;
   final Color accentColor;
   final Logger log;
 
-  final Widget Function(BuildContext context) builder;
+  final WidgetBuilder builder;
 
   SailApp({
     required this.builder,
-    required this.initMethod,
     required this.accentColor,
     required this.log,
+    this.initMethod,
   }) : super(key: sailAppKey);
 
   @override
@@ -49,7 +49,7 @@ class SailAppState extends State<SailApp> with WidgetsBindingObserver {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     unawaited(loadTheme());
-    widget.initMethod(context);
+    widget.initMethod?.call(context);
   }
 
   Future<void> loadTheme([SailThemeValues? themeToLoad]) async {


### PR DESCRIPTION
Would make sense imo, `initMethod` is not used anywhere yet either