### PR TITLE
drivechain-server: use user-space data directory for bdk-cli data

### DIFF
--- a/drivechain-server/main.go
+++ b/drivechain-server/main.go
@@ -179,6 +179,7 @@ func getDataDir() (string, error) {
 
 	switch runtime.GOOS {
 	case "linux":
+	case "darwin":
 		if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
 			dir = filepath.Join(xdgDataHome, appName)
 		} else {
@@ -186,22 +187,20 @@ func getDataDir() (string, error) {
 			if err != nil {
 				return "", err
 			}
-			dir = filepath.Join(home, ".local", "share", appName)
+			if runtime.GOOS == "darwin" {
+				dir = filepath.Join(home, "Library", "Application Support", appName)
+			} else {
+				dir = filepath.Join(home, ".local", "share", appName)
+			}
 		}
-	case "darwin":
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		dir = filepath.Join(home, "Library", "Application Support", appName)
 	case "windows":
 		appData, ok := os.LookupEnv("APPDATA")
 		if !ok {
-			return "", os.ErrNotExist
+			return "", fmt.Errorf("APPDATA environment variable not set")
 		}
 		dir = filepath.Join(appData, appName)
 	default:
-		return "", os.ErrNotExist
+		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
 
 	// Ensure the directory exists


### PR DESCRIPTION
Resolves #226 by retrieving the common data directory for the runtime OS.

On Linux and macOS, we first look up `XDG_DATA_HOME` before defaulting to the common directories (`$HOME/.local/share` on Linux, `$HOME/Library/Application Support` on macOS).

On Windows, use the `APPDATA` environment variable, this should always be set.