### PR TITLE
drivechain-server: embed bdk-cli with application

### DIFF
--- a/drivechain-server/.gitignore
+++ b/drivechain-server/.gitignore
@@ -1,1 +1,3 @@
 drivechain-server
+/bdk/bin/
+/bdk/.crates*

--- a/drivechain-server/Justfile
+++ b/drivechain-server/Justfile
@@ -1,14 +1,41 @@
-build:
+build-go:
     go build -o drivechain-server .
 
-lint: 
+build: build-bdk-cli build-go
+
+clean:
+    rm -rf ./bdk/bin
+    go clean
+
+lint:
     golangci-lint run ./...
 
-gen: 
+gen:
     buf generate
 
 install-bdk-cli:
     cargo install \
         --git https://github.com/bitcoindevkit/bdk-cli \
         --no-default-features \
-        --features=key-value-db,compiler,electrum  
+        --features=key-value-db,compiler,electrum
+
+build-bdk-cli:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f "./bdk/bin/bdk-cli" ]; then
+        echo "Building bdk-cli..."
+        mkdir -p ./bin
+        if ! command -v rustc &> /dev/null; then
+            echo "Error: Rust is not installed. Please install Rust and try again."
+            exit 1
+        fi
+        cargo install \
+        --git https://github.com/bitcoindevkit/bdk-cli.git \
+        --tag v0.27.1 \
+        --root ./bdk \
+        --no-default-features \
+        --features=key-value-db,compiler,electrum
+        echo "bdk-cli has been built to ./bin/bdk-cli."
+    else
+        echo "bdk-cli already exists. Skipping build."
+    fi


### PR DESCRIPTION
Resolves #223 by adding a script for building bdk-cli and using the [embed](https://pkg.go.dev/embed) package to embed the binary into the Go application. 

Currently pinned to the latest release, not sure if we want to pin versions or always use the latest but bdk-cli seems to be relatively stable now.