### PR TITLE
faucet: generate types from btcbuf

### DIFF
--- a/drivechain-server/buf.yaml
+++ b/drivechain-server/buf.yaml
@@ -1,4 +1,4 @@
-# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yamlG
+# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yaml
 version: v2
 lint:
   rpc_allow_google_protobuf_empty_requests: true

--- a/packages/faucet/Justfile
+++ b/packages/faucet/Justfile
@@ -1,0 +1,2 @@
+gen:
+    buf generate

--- a/packages/faucet/buf.gen.yaml
+++ b/packages/faucet/buf.gen.yaml
@@ -1,0 +1,14 @@
+version: v2
+
+managed:
+  enabled: true
+
+plugins:
+  - remote: buf.build/protocolbuffers/dart:v21.1.2
+    out: lib/gen
+    include_wkt: true
+    include_imports: true
+
+inputs:
+  # The backend uses btc-buf
+  - module: buf.build/bitcoin/bitcoind

--- a/packages/faucet/buf.yaml
+++ b/packages/faucet/buf.yaml
@@ -1,4 +1,4 @@
-# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yamlG
+# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yaml
 version: v2
 
 lint:

--- a/packages/faucet/buf.yaml
+++ b/packages/faucet/buf.yaml
@@ -1,0 +1,12 @@
+# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yamlG
+version: v2
+
+lint:
+  rpc_allow_google_protobuf_empty_requests: true
+  rpc_allow_google_protobuf_empty_responses: true
+  use:
+    - DEFAULT
+
+breaking:
+  use:
+    - FILE

--- a/packages/faucet/lib/api/api.dart
+++ b/packages/faucet/lib/api/api.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:faucet/gen/bitcoin/bitcoind/v1alpha/bitcoin.pb.dart';
 import 'package:http/http.dart' as http;
 import 'package:sail_ui/bitcoin.dart';
-import 'package:sail_ui/sail_ui.dart';
 
 /// RPC connection to the mainchain node.
 abstract class API {
@@ -11,7 +11,7 @@ abstract class API {
 
   API({required this.apiURL});
 
-  Future<List<UTXO>> listClaims();
+  Future<List<GetTransactionResponse>> listClaims();
   Future<String> claim(String address, double amount);
 }
 
@@ -19,14 +19,16 @@ class APILive extends API {
   APILive({required super.apiURL});
 
   @override
-  Future<List<UTXO>> listClaims() async {
+  Future<List<GetTransactionResponse>> listClaims() async {
     final url = Uri.parse("$apiURL/listclaims");
     final res = await http.get(url);
 
     if (res.statusCode == 200) {
       final List<dynamic> claimsJSON = jsonDecode(res.body);
 
-      List<UTXO> transactions = claimsJSON.map((jsonItem) => UTXO.fromMap(jsonItem)).toList();
+      List<GetTransactionResponse> transactions =
+          claimsJSON.map((jsonItem) => GetTransactionResponse.fromJson(jsonItem)).toList();
+
       return transactions;
     } else {
       throw Exception('could not list claims');

--- a/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pb.dart
+++ b/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pb.dart
@@ -1,0 +1,4427 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/bitcoind/v1alpha/bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:async' as $async;
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import '../../../google/protobuf/timestamp.pb.dart' as $0;
+import '../../../google/protobuf/wrappers.pb.dart' as $1;
+import 'bitcoin.pbenum.dart';
+
+export 'bitcoin.pbenum.dart';
+
+class GetBlockchainInfoRequest extends $pb.GeneratedMessage {
+  factory GetBlockchainInfoRequest() => create();
+  GetBlockchainInfoRequest._() : super();
+  factory GetBlockchainInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockchainInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockchainInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBlockchainInfoRequest clone() => GetBlockchainInfoRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockchainInfoRequest copyWith(void Function(GetBlockchainInfoRequest) updates) => super.copyWith((message) => updates(message as GetBlockchainInfoRequest)) as GetBlockchainInfoRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBlockchainInfoRequest create() => GetBlockchainInfoRequest._();
+  GetBlockchainInfoRequest createEmptyInstance() => create();
+  static $pb.PbList<GetBlockchainInfoRequest> createRepeated() => $pb.PbList<GetBlockchainInfoRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetBlockchainInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockchainInfoRequest>(create);
+  static GetBlockchainInfoRequest? _defaultInstance;
+}
+
+class GetBlockchainInfoResponse extends $pb.GeneratedMessage {
+  factory GetBlockchainInfoResponse({
+    $core.String? bestBlockHash,
+    $core.String? chain,
+    $core.String? chainWork,
+    $core.bool? initialBlockDownload,
+    $core.int? blocks,
+    $core.int? headers,
+  }) {
+    final $result = create();
+    if (bestBlockHash != null) {
+      $result.bestBlockHash = bestBlockHash;
+    }
+    if (chain != null) {
+      $result.chain = chain;
+    }
+    if (chainWork != null) {
+      $result.chainWork = chainWork;
+    }
+    if (initialBlockDownload != null) {
+      $result.initialBlockDownload = initialBlockDownload;
+    }
+    if (blocks != null) {
+      $result.blocks = blocks;
+    }
+    if (headers != null) {
+      $result.headers = headers;
+    }
+    return $result;
+  }
+  GetBlockchainInfoResponse._() : super();
+  factory GetBlockchainInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockchainInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockchainInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'bestBlockHash')
+    ..aOS(2, _omitFieldNames ? '' : 'chain')
+    ..aOS(3, _omitFieldNames ? '' : 'chainWork')
+    ..aOB(4, _omitFieldNames ? '' : 'initialBlockDownload')
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'blocks', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'headers', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBlockchainInfoResponse clone() => GetBlockchainInfoResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockchainInfoResponse copyWith(void Function(GetBlockchainInfoResponse) updates) => super.copyWith((message) => updates(message as GetBlockchainInfoResponse)) as GetBlockchainInfoResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBlockchainInfoResponse create() => GetBlockchainInfoResponse._();
+  GetBlockchainInfoResponse createEmptyInstance() => create();
+  static $pb.PbList<GetBlockchainInfoResponse> createRepeated() => $pb.PbList<GetBlockchainInfoResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetBlockchainInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockchainInfoResponse>(create);
+  static GetBlockchainInfoResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get bestBlockHash => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set bestBlockHash($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasBestBlockHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBestBlockHash() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get chain => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set chain($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasChain() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearChain() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get chainWork => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set chainWork($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasChainWork() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearChainWork() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get initialBlockDownload => $_getBF(3);
+  @$pb.TagNumber(4)
+  set initialBlockDownload($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasInitialBlockDownload() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearInitialBlockDownload() => clearField(4);
+
+  /// The height of the most-work fully-validated chain.
+  @$pb.TagNumber(5)
+  $core.int get blocks => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set blocks($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasBlocks() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearBlocks() => clearField(5);
+
+  /// The current number of validated headers.
+  @$pb.TagNumber(6)
+  $core.int get headers => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set headers($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasHeaders() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearHeaders() => clearField(6);
+}
+
+class GetNewAddressRequest extends $pb.GeneratedMessage {
+  factory GetNewAddressRequest({
+    $core.String? label,
+    $core.String? addressType,
+    $core.String? wallet,
+  }) {
+    final $result = create();
+    if (label != null) {
+      $result.label = label;
+    }
+    if (addressType != null) {
+      $result.addressType = addressType;
+    }
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    return $result;
+  }
+  GetNewAddressRequest._() : super();
+  factory GetNewAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'label')
+    ..aOS(2, _omitFieldNames ? '' : 'addressType')
+    ..aOS(3, _omitFieldNames ? '' : 'wallet')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest clone() => GetNewAddressRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressRequest copyWith(void Function(GetNewAddressRequest) updates) => super.copyWith((message) => updates(message as GetNewAddressRequest)) as GetNewAddressRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetNewAddressRequest create() => GetNewAddressRequest._();
+  GetNewAddressRequest createEmptyInstance() => create();
+  static $pb.PbList<GetNewAddressRequest> createRepeated() => $pb.PbList<GetNewAddressRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetNewAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressRequest>(create);
+  static GetNewAddressRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get label => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set label($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasLabel() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearLabel() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get addressType => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set addressType($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddressType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddressType() => clearField(2);
+
+  /// Only needs to be set if dealing with multiple wallets at the same time.
+  /// TODO: better suited as a header?
+  @$pb.TagNumber(3)
+  $core.String get wallet => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set wallet($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasWallet() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearWallet() => clearField(3);
+}
+
+class GetNewAddressResponse extends $pb.GeneratedMessage {
+  factory GetNewAddressResponse({
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  GetNewAddressResponse._() : super();
+  factory GetNewAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetNewAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetNewAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'address')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse clone() => GetNewAddressResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetNewAddressResponse copyWith(void Function(GetNewAddressResponse) updates) => super.copyWith((message) => updates(message as GetNewAddressResponse)) as GetNewAddressResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetNewAddressResponse create() => GetNewAddressResponse._();
+  GetNewAddressResponse createEmptyInstance() => create();
+  static $pb.PbList<GetNewAddressResponse> createRepeated() => $pb.PbList<GetNewAddressResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetNewAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetNewAddressResponse>(create);
+  static GetNewAddressResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+}
+
+class GetWalletInfoRequest extends $pb.GeneratedMessage {
+  factory GetWalletInfoRequest({
+    $core.String? wallet,
+  }) {
+    final $result = create();
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    return $result;
+  }
+  GetWalletInfoRequest._() : super();
+  factory GetWalletInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'wallet')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetWalletInfoRequest clone() => GetWalletInfoRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletInfoRequest copyWith(void Function(GetWalletInfoRequest) updates) => super.copyWith((message) => updates(message as GetWalletInfoRequest)) as GetWalletInfoRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetWalletInfoRequest create() => GetWalletInfoRequest._();
+  GetWalletInfoRequest createEmptyInstance() => create();
+  static $pb.PbList<GetWalletInfoRequest> createRepeated() => $pb.PbList<GetWalletInfoRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetWalletInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletInfoRequest>(create);
+  static GetWalletInfoRequest? _defaultInstance;
+
+  /// Only needs to be set if dealing with multiple wallets at the same time.
+  /// TODO: better suited as a header?
+  @$pb.TagNumber(1)
+  $core.String get wallet => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set wallet($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWallet() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWallet() => clearField(1);
+}
+
+class GetWalletInfoResponse extends $pb.GeneratedMessage {
+  factory GetWalletInfoResponse({
+    $core.String? walletName,
+    $fixnum.Int64? walletVersion,
+    $core.String? format,
+    $fixnum.Int64? txCount,
+    $fixnum.Int64? keyPoolSize,
+    $fixnum.Int64? keyPoolSizeHdInternal,
+    $core.double? payTxFee,
+    $core.bool? privateKeysEnabled,
+    $core.bool? avoidReuse,
+    WalletScan? scanning,
+    $core.bool? descriptors,
+    $core.bool? externalSigner,
+  }) {
+    final $result = create();
+    if (walletName != null) {
+      $result.walletName = walletName;
+    }
+    if (walletVersion != null) {
+      $result.walletVersion = walletVersion;
+    }
+    if (format != null) {
+      $result.format = format;
+    }
+    if (txCount != null) {
+      $result.txCount = txCount;
+    }
+    if (keyPoolSize != null) {
+      $result.keyPoolSize = keyPoolSize;
+    }
+    if (keyPoolSizeHdInternal != null) {
+      $result.keyPoolSizeHdInternal = keyPoolSizeHdInternal;
+    }
+    if (payTxFee != null) {
+      $result.payTxFee = payTxFee;
+    }
+    if (privateKeysEnabled != null) {
+      $result.privateKeysEnabled = privateKeysEnabled;
+    }
+    if (avoidReuse != null) {
+      $result.avoidReuse = avoidReuse;
+    }
+    if (scanning != null) {
+      $result.scanning = scanning;
+    }
+    if (descriptors != null) {
+      $result.descriptors = descriptors;
+    }
+    if (externalSigner != null) {
+      $result.externalSigner = externalSigner;
+    }
+    return $result;
+  }
+  GetWalletInfoResponse._() : super();
+  factory GetWalletInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetWalletInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetWalletInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'walletName')
+    ..aInt64(2, _omitFieldNames ? '' : 'walletVersion')
+    ..aOS(3, _omitFieldNames ? '' : 'format')
+    ..aInt64(7, _omitFieldNames ? '' : 'txCount')
+    ..aInt64(8, _omitFieldNames ? '' : 'keyPoolSize')
+    ..aInt64(9, _omitFieldNames ? '' : 'keyPoolSizeHdInternal')
+    ..a<$core.double>(10, _omitFieldNames ? '' : 'payTxFee', $pb.PbFieldType.OD)
+    ..aOB(11, _omitFieldNames ? '' : 'privateKeysEnabled')
+    ..aOB(12, _omitFieldNames ? '' : 'avoidReuse')
+    ..aOM<WalletScan>(13, _omitFieldNames ? '' : 'scanning', subBuilder: WalletScan.create)
+    ..aOB(14, _omitFieldNames ? '' : 'descriptors')
+    ..aOB(15, _omitFieldNames ? '' : 'externalSigner')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetWalletInfoResponse clone() => GetWalletInfoResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetWalletInfoResponse copyWith(void Function(GetWalletInfoResponse) updates) => super.copyWith((message) => updates(message as GetWalletInfoResponse)) as GetWalletInfoResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetWalletInfoResponse create() => GetWalletInfoResponse._();
+  GetWalletInfoResponse createEmptyInstance() => create();
+  static $pb.PbList<GetWalletInfoResponse> createRepeated() => $pb.PbList<GetWalletInfoResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetWalletInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetWalletInfoResponse>(create);
+  static GetWalletInfoResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get walletName => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set walletName($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWalletName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWalletName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get walletVersion => $_getI64(1);
+  @$pb.TagNumber(2)
+  set walletVersion($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWalletVersion() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWalletVersion() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get format => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set format($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFormat() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFormat() => clearField(3);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get txCount => $_getI64(3);
+  @$pb.TagNumber(7)
+  set txCount($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasTxCount() => $_has(3);
+  @$pb.TagNumber(7)
+  void clearTxCount() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $fixnum.Int64 get keyPoolSize => $_getI64(4);
+  @$pb.TagNumber(8)
+  set keyPoolSize($fixnum.Int64 v) { $_setInt64(4, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasKeyPoolSize() => $_has(4);
+  @$pb.TagNumber(8)
+  void clearKeyPoolSize() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $fixnum.Int64 get keyPoolSizeHdInternal => $_getI64(5);
+  @$pb.TagNumber(9)
+  set keyPoolSizeHdInternal($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasKeyPoolSizeHdInternal() => $_has(5);
+  @$pb.TagNumber(9)
+  void clearKeyPoolSizeHdInternal() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.double get payTxFee => $_getN(6);
+  @$pb.TagNumber(10)
+  set payTxFee($core.double v) { $_setDouble(6, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasPayTxFee() => $_has(6);
+  @$pb.TagNumber(10)
+  void clearPayTxFee() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.bool get privateKeysEnabled => $_getBF(7);
+  @$pb.TagNumber(11)
+  set privateKeysEnabled($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasPrivateKeysEnabled() => $_has(7);
+  @$pb.TagNumber(11)
+  void clearPrivateKeysEnabled() => clearField(11);
+
+  @$pb.TagNumber(12)
+  $core.bool get avoidReuse => $_getBF(8);
+  @$pb.TagNumber(12)
+  set avoidReuse($core.bool v) { $_setBool(8, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasAvoidReuse() => $_has(8);
+  @$pb.TagNumber(12)
+  void clearAvoidReuse() => clearField(12);
+
+  /// Not set if no scan is in progress.
+  @$pb.TagNumber(13)
+  WalletScan get scanning => $_getN(9);
+  @$pb.TagNumber(13)
+  set scanning(WalletScan v) { setField(13, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasScanning() => $_has(9);
+  @$pb.TagNumber(13)
+  void clearScanning() => clearField(13);
+  @$pb.TagNumber(13)
+  WalletScan ensureScanning() => $_ensure(9);
+
+  @$pb.TagNumber(14)
+  $core.bool get descriptors => $_getBF(10);
+  @$pb.TagNumber(14)
+  set descriptors($core.bool v) { $_setBool(10, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasDescriptors() => $_has(10);
+  @$pb.TagNumber(14)
+  void clearDescriptors() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.bool get externalSigner => $_getBF(11);
+  @$pb.TagNumber(15)
+  set externalSigner($core.bool v) { $_setBool(11, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasExternalSigner() => $_has(11);
+  @$pb.TagNumber(15)
+  void clearExternalSigner() => clearField(15);
+}
+
+class GetBalancesRequest extends $pb.GeneratedMessage {
+  factory GetBalancesRequest({
+    $core.String? wallet,
+  }) {
+    final $result = create();
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    return $result;
+  }
+  GetBalancesRequest._() : super();
+  factory GetBalancesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalancesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalancesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'wallet')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBalancesRequest clone() => GetBalancesRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalancesRequest copyWith(void Function(GetBalancesRequest) updates) => super.copyWith((message) => updates(message as GetBalancesRequest)) as GetBalancesRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesRequest create() => GetBalancesRequest._();
+  GetBalancesRequest createEmptyInstance() => create();
+  static $pb.PbList<GetBalancesRequest> createRepeated() => $pb.PbList<GetBalancesRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalancesRequest>(create);
+  static GetBalancesRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get wallet => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set wallet($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWallet() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWallet() => clearField(1);
+}
+
+/// balances from outputs that the wallet can sign
+class GetBalancesResponse_Mine extends $pb.GeneratedMessage {
+  factory GetBalancesResponse_Mine({
+    $core.double? trusted,
+    $core.double? untrustedPending,
+    $core.double? immature,
+    $core.double? used,
+  }) {
+    final $result = create();
+    if (trusted != null) {
+      $result.trusted = trusted;
+    }
+    if (untrustedPending != null) {
+      $result.untrustedPending = untrustedPending;
+    }
+    if (immature != null) {
+      $result.immature = immature;
+    }
+    if (used != null) {
+      $result.used = used;
+    }
+    return $result;
+  }
+  GetBalancesResponse_Mine._() : super();
+  factory GetBalancesResponse_Mine.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalancesResponse_Mine.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalancesResponse.Mine', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'trusted', $pb.PbFieldType.OD)
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'untrustedPending', $pb.PbFieldType.OD)
+    ..a<$core.double>(3, _omitFieldNames ? '' : 'immature', $pb.PbFieldType.OD)
+    ..a<$core.double>(4, _omitFieldNames ? '' : 'used', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBalancesResponse_Mine clone() => GetBalancesResponse_Mine()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalancesResponse_Mine copyWith(void Function(GetBalancesResponse_Mine) updates) => super.copyWith((message) => updates(message as GetBalancesResponse_Mine)) as GetBalancesResponse_Mine;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesResponse_Mine create() => GetBalancesResponse_Mine._();
+  GetBalancesResponse_Mine createEmptyInstance() => create();
+  static $pb.PbList<GetBalancesResponse_Mine> createRepeated() => $pb.PbList<GetBalancesResponse_Mine>();
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesResponse_Mine getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalancesResponse_Mine>(create);
+  static GetBalancesResponse_Mine? _defaultInstance;
+
+  /// trusted balance (outputs created by the wallet or confirmed outputs)
+  @$pb.TagNumber(1)
+  $core.double get trusted => $_getN(0);
+  @$pb.TagNumber(1)
+  set trusted($core.double v) { $_setDouble(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTrusted() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTrusted() => clearField(1);
+
+  /// untrusted pending balance (outputs created by others that are in the mempool)
+  @$pb.TagNumber(2)
+  $core.double get untrustedPending => $_getN(1);
+  @$pb.TagNumber(2)
+  set untrustedPending($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasUntrustedPending() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearUntrustedPending() => clearField(2);
+
+  /// balance from immature coinbase outputs
+  @$pb.TagNumber(3)
+  $core.double get immature => $_getN(2);
+  @$pb.TagNumber(3)
+  set immature($core.double v) { $_setDouble(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasImmature() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearImmature() => clearField(3);
+
+  /// only present if avoid_reuse is set) balance from coins sent to addresses that were previously spent from (potentially privacy violating
+  @$pb.TagNumber(4)
+  $core.double get used => $_getN(3);
+  @$pb.TagNumber(4)
+  set used($core.double v) { $_setDouble(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasUsed() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearUsed() => clearField(4);
+}
+
+/// watchonly balances (not present if wallet does not watch anything)
+class GetBalancesResponse_Watchonly extends $pb.GeneratedMessage {
+  factory GetBalancesResponse_Watchonly({
+    $core.double? trusted,
+    $core.double? untrustedPending,
+    $core.double? immature,
+  }) {
+    final $result = create();
+    if (trusted != null) {
+      $result.trusted = trusted;
+    }
+    if (untrustedPending != null) {
+      $result.untrustedPending = untrustedPending;
+    }
+    if (immature != null) {
+      $result.immature = immature;
+    }
+    return $result;
+  }
+  GetBalancesResponse_Watchonly._() : super();
+  factory GetBalancesResponse_Watchonly.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalancesResponse_Watchonly.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalancesResponse.Watchonly', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'trusted', $pb.PbFieldType.OD)
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'untrustedPending', $pb.PbFieldType.OD)
+    ..a<$core.double>(3, _omitFieldNames ? '' : 'immature', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBalancesResponse_Watchonly clone() => GetBalancesResponse_Watchonly()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalancesResponse_Watchonly copyWith(void Function(GetBalancesResponse_Watchonly) updates) => super.copyWith((message) => updates(message as GetBalancesResponse_Watchonly)) as GetBalancesResponse_Watchonly;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesResponse_Watchonly create() => GetBalancesResponse_Watchonly._();
+  GetBalancesResponse_Watchonly createEmptyInstance() => create();
+  static $pb.PbList<GetBalancesResponse_Watchonly> createRepeated() => $pb.PbList<GetBalancesResponse_Watchonly>();
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesResponse_Watchonly getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalancesResponse_Watchonly>(create);
+  static GetBalancesResponse_Watchonly? _defaultInstance;
+
+  /// trusted balance (outputs created by the wallet or confirmed outputs)
+  @$pb.TagNumber(1)
+  $core.double get trusted => $_getN(0);
+  @$pb.TagNumber(1)
+  set trusted($core.double v) { $_setDouble(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTrusted() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTrusted() => clearField(1);
+
+  /// untrusted pending balance (outputs created by others that are in the mempool)
+  @$pb.TagNumber(2)
+  $core.double get untrustedPending => $_getN(1);
+  @$pb.TagNumber(2)
+  set untrustedPending($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasUntrustedPending() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearUntrustedPending() => clearField(2);
+
+  /// balance from immature coinbase outputs
+  @$pb.TagNumber(3)
+  $core.double get immature => $_getN(2);
+  @$pb.TagNumber(3)
+  set immature($core.double v) { $_setDouble(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasImmature() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearImmature() => clearField(3);
+}
+
+class GetBalancesResponse extends $pb.GeneratedMessage {
+  factory GetBalancesResponse({
+    GetBalancesResponse_Mine? mine,
+    GetBalancesResponse_Watchonly? watchonly,
+  }) {
+    final $result = create();
+    if (mine != null) {
+      $result.mine = mine;
+    }
+    if (watchonly != null) {
+      $result.watchonly = watchonly;
+    }
+    return $result;
+  }
+  GetBalancesResponse._() : super();
+  factory GetBalancesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBalancesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBalancesResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOM<GetBalancesResponse_Mine>(1, _omitFieldNames ? '' : 'mine', subBuilder: GetBalancesResponse_Mine.create)
+    ..aOM<GetBalancesResponse_Watchonly>(2, _omitFieldNames ? '' : 'watchonly', subBuilder: GetBalancesResponse_Watchonly.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBalancesResponse clone() => GetBalancesResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBalancesResponse copyWith(void Function(GetBalancesResponse) updates) => super.copyWith((message) => updates(message as GetBalancesResponse)) as GetBalancesResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesResponse create() => GetBalancesResponse._();
+  GetBalancesResponse createEmptyInstance() => create();
+  static $pb.PbList<GetBalancesResponse> createRepeated() => $pb.PbList<GetBalancesResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetBalancesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBalancesResponse>(create);
+  static GetBalancesResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  GetBalancesResponse_Mine get mine => $_getN(0);
+  @$pb.TagNumber(1)
+  set mine(GetBalancesResponse_Mine v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMine() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMine() => clearField(1);
+  @$pb.TagNumber(1)
+  GetBalancesResponse_Mine ensureMine() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  GetBalancesResponse_Watchonly get watchonly => $_getN(1);
+  @$pb.TagNumber(2)
+  set watchonly(GetBalancesResponse_Watchonly v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWatchonly() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWatchonly() => clearField(2);
+  @$pb.TagNumber(2)
+  GetBalancesResponse_Watchonly ensureWatchonly() => $_ensure(1);
+}
+
+class WalletScan extends $pb.GeneratedMessage {
+  factory WalletScan({
+    $fixnum.Int64? duration,
+    $core.double? progress,
+  }) {
+    final $result = create();
+    if (duration != null) {
+      $result.duration = duration;
+    }
+    if (progress != null) {
+      $result.progress = progress;
+    }
+    return $result;
+  }
+  WalletScan._() : super();
+  factory WalletScan.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WalletScan.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'WalletScan', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aInt64(1, _omitFieldNames ? '' : 'duration')
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'progress', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WalletScan clone() => WalletScan()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WalletScan copyWith(void Function(WalletScan) updates) => super.copyWith((message) => updates(message as WalletScan)) as WalletScan;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static WalletScan create() => WalletScan._();
+  WalletScan createEmptyInstance() => create();
+  static $pb.PbList<WalletScan> createRepeated() => $pb.PbList<WalletScan>();
+  @$core.pragma('dart2js:noInline')
+  static WalletScan getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WalletScan>(create);
+  static WalletScan? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get duration => $_getI64(0);
+  @$pb.TagNumber(1)
+  set duration($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDuration() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDuration() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.double get progress => $_getN(1);
+  @$pb.TagNumber(2)
+  set progress($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasProgress() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearProgress() => clearField(2);
+}
+
+class GetTransactionRequest extends $pb.GeneratedMessage {
+  factory GetTransactionRequest({
+    $core.String? txid,
+    $core.bool? includeWatchonly,
+    $core.bool? verbose,
+    $core.String? wallet,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (includeWatchonly != null) {
+      $result.includeWatchonly = includeWatchonly;
+    }
+    if (verbose != null) {
+      $result.verbose = verbose;
+    }
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    return $result;
+  }
+  GetTransactionRequest._() : super();
+  factory GetTransactionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..aOB(2, _omitFieldNames ? '' : 'includeWatchonly')
+    ..aOB(3, _omitFieldNames ? '' : 'verbose')
+    ..aOS(4, _omitFieldNames ? '' : 'wallet')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetTransactionRequest clone() => GetTransactionRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionRequest copyWith(void Function(GetTransactionRequest) updates) => super.copyWith((message) => updates(message as GetTransactionRequest)) as GetTransactionRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetTransactionRequest create() => GetTransactionRequest._();
+  GetTransactionRequest createEmptyInstance() => create();
+  static $pb.PbList<GetTransactionRequest> createRepeated() => $pb.PbList<GetTransactionRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetTransactionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionRequest>(create);
+  static GetTransactionRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get includeWatchonly => $_getBF(1);
+  @$pb.TagNumber(2)
+  set includeWatchonly($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasIncludeWatchonly() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearIncludeWatchonly() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get verbose => $_getBF(2);
+  @$pb.TagNumber(3)
+  set verbose($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasVerbose() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearVerbose() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get wallet => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set wallet($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasWallet() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearWallet() => clearField(4);
+}
+
+class GetTransactionResponse_Details extends $pb.GeneratedMessage {
+  factory GetTransactionResponse_Details({
+    $core.bool? involvesWatchOnly,
+    $core.String? address,
+    GetTransactionResponse_Category? category,
+    $core.double? amount,
+    $core.int? vout,
+    $core.double? fee,
+  }) {
+    final $result = create();
+    if (involvesWatchOnly != null) {
+      $result.involvesWatchOnly = involvesWatchOnly;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    if (category != null) {
+      $result.category = category;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (vout != null) {
+      $result.vout = vout;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    return $result;
+  }
+  GetTransactionResponse_Details._() : super();
+  factory GetTransactionResponse_Details.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionResponse_Details.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionResponse.Details', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'involvesWatchOnly')
+    ..aOS(2, _omitFieldNames ? '' : 'address')
+    ..e<GetTransactionResponse_Category>(3, _omitFieldNames ? '' : 'category', $pb.PbFieldType.OE, defaultOrMaker: GetTransactionResponse_Category.CATEGORY_UNSPECIFIED, valueOf: GetTransactionResponse_Category.valueOf, enumValues: GetTransactionResponse_Category.values)
+    ..a<$core.double>(4, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OD)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'vout', $pb.PbFieldType.OU3)
+    ..a<$core.double>(7, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetTransactionResponse_Details clone() => GetTransactionResponse_Details()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionResponse_Details copyWith(void Function(GetTransactionResponse_Details) updates) => super.copyWith((message) => updates(message as GetTransactionResponse_Details)) as GetTransactionResponse_Details;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetTransactionResponse_Details create() => GetTransactionResponse_Details._();
+  GetTransactionResponse_Details createEmptyInstance() => create();
+  static $pb.PbList<GetTransactionResponse_Details> createRepeated() => $pb.PbList<GetTransactionResponse_Details>();
+  @$core.pragma('dart2js:noInline')
+  static GetTransactionResponse_Details getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionResponse_Details>(create);
+  static GetTransactionResponse_Details? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get involvesWatchOnly => $_getBF(0);
+  @$pb.TagNumber(1)
+  set involvesWatchOnly($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasInvolvesWatchOnly() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearInvolvesWatchOnly() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get address => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set address($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddress() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddress() => clearField(2);
+
+  /// TODO: enum - send, receive, generate, immature, orphan
+  @$pb.TagNumber(3)
+  GetTransactionResponse_Category get category => $_getN(2);
+  @$pb.TagNumber(3)
+  set category(GetTransactionResponse_Category v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCategory() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCategory() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.double get amount => $_getN(3);
+  @$pb.TagNumber(4)
+  set amount($core.double v) { $_setDouble(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAmount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAmount() => clearField(4);
+
+  /// string label = 5;
+  @$pb.TagNumber(6)
+  $core.int get vout => $_getIZ(4);
+  @$pb.TagNumber(6)
+  set vout($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasVout() => $_has(4);
+  @$pb.TagNumber(6)
+  void clearVout() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.double get fee => $_getN(5);
+  @$pb.TagNumber(7)
+  set fee($core.double v) { $_setDouble(5, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasFee() => $_has(5);
+  @$pb.TagNumber(7)
+  void clearFee() => clearField(7);
+}
+
+/// Commented fields are not present in btcd/rpcclient
+class GetTransactionResponse extends $pb.GeneratedMessage {
+  factory GetTransactionResponse({
+    $core.double? amount,
+    $core.double? fee,
+    $core.int? confirmations,
+    $core.String? blockHash,
+    $core.int? blockIndex,
+    $0.Timestamp? blockTime,
+    $core.String? txid,
+    $core.Iterable<$core.String>? walletConflicts,
+    $core.String? replacedByTxid,
+    $core.String? replacesTxid,
+    $0.Timestamp? time,
+    $0.Timestamp? timeReceived,
+    GetTransactionResponse_Replaceable? bip125Replaceable,
+    $core.Iterable<GetTransactionResponse_Details>? details,
+    $core.String? hex,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    if (confirmations != null) {
+      $result.confirmations = confirmations;
+    }
+    if (blockHash != null) {
+      $result.blockHash = blockHash;
+    }
+    if (blockIndex != null) {
+      $result.blockIndex = blockIndex;
+    }
+    if (blockTime != null) {
+      $result.blockTime = blockTime;
+    }
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (walletConflicts != null) {
+      $result.walletConflicts.addAll(walletConflicts);
+    }
+    if (replacedByTxid != null) {
+      $result.replacedByTxid = replacedByTxid;
+    }
+    if (replacesTxid != null) {
+      $result.replacesTxid = replacesTxid;
+    }
+    if (time != null) {
+      $result.time = time;
+    }
+    if (timeReceived != null) {
+      $result.timeReceived = timeReceived;
+    }
+    if (bip125Replaceable != null) {
+      $result.bip125Replaceable = bip125Replaceable;
+    }
+    if (details != null) {
+      $result.details.addAll(details);
+    }
+    if (hex != null) {
+      $result.hex = hex;
+    }
+    return $result;
+  }
+  GetTransactionResponse._() : super();
+  factory GetTransactionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetTransactionResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OD)
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.OD)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'confirmations', $pb.PbFieldType.O3)
+    ..aOS(6, _omitFieldNames ? '' : 'blockHash')
+    ..a<$core.int>(8, _omitFieldNames ? '' : 'blockIndex', $pb.PbFieldType.OU3)
+    ..aOM<$0.Timestamp>(9, _omitFieldNames ? '' : 'blockTime', subBuilder: $0.Timestamp.create)
+    ..aOS(10, _omitFieldNames ? '' : 'txid')
+    ..pPS(12, _omitFieldNames ? '' : 'walletConflicts')
+    ..aOS(13, _omitFieldNames ? '' : 'replacedByTxid')
+    ..aOS(14, _omitFieldNames ? '' : 'replacesTxid')
+    ..aOM<$0.Timestamp>(17, _omitFieldNames ? '' : 'time', subBuilder: $0.Timestamp.create)
+    ..aOM<$0.Timestamp>(18, _omitFieldNames ? '' : 'timeReceived', subBuilder: $0.Timestamp.create)
+    ..e<GetTransactionResponse_Replaceable>(19, _omitFieldNames ? '' : 'bip125Replaceable', $pb.PbFieldType.OE, defaultOrMaker: GetTransactionResponse_Replaceable.REPLACEABLE_UNSPECIFIED, valueOf: GetTransactionResponse_Replaceable.valueOf, enumValues: GetTransactionResponse_Replaceable.values)
+    ..pc<GetTransactionResponse_Details>(21, _omitFieldNames ? '' : 'details', $pb.PbFieldType.PM, subBuilder: GetTransactionResponse_Details.create)
+    ..aOS(22, _omitFieldNames ? '' : 'hex')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetTransactionResponse clone() => GetTransactionResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetTransactionResponse copyWith(void Function(GetTransactionResponse) updates) => super.copyWith((message) => updates(message as GetTransactionResponse)) as GetTransactionResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetTransactionResponse create() => GetTransactionResponse._();
+  GetTransactionResponse createEmptyInstance() => create();
+  static $pb.PbList<GetTransactionResponse> createRepeated() => $pb.PbList<GetTransactionResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetTransactionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetTransactionResponse>(create);
+  static GetTransactionResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.double get amount => $_getN(0);
+  @$pb.TagNumber(1)
+  set amount($core.double v) { $_setDouble(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.double get fee => $_getN(1);
+  @$pb.TagNumber(2)
+  set fee($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFee() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFee() => clearField(2);
+
+  /// The number of confirmations for the transaction. Negative
+  /// confirmations means the transaction conflicted that many
+  /// blocks ago.
+  @$pb.TagNumber(3)
+  $core.int get confirmations => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set confirmations($core.int v) { $_setSignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasConfirmations() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearConfirmations() => clearField(3);
+
+  /// bool generated = 4;
+  /// bool trusted = 5;
+  @$pb.TagNumber(6)
+  $core.String get blockHash => $_getSZ(3);
+  @$pb.TagNumber(6)
+  set blockHash($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasBlockHash() => $_has(3);
+  @$pb.TagNumber(6)
+  void clearBlockHash() => clearField(6);
+
+  /// string block_height = 7;
+  @$pb.TagNumber(8)
+  $core.int get blockIndex => $_getIZ(4);
+  @$pb.TagNumber(8)
+  set blockIndex($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasBlockIndex() => $_has(4);
+  @$pb.TagNumber(8)
+  void clearBlockIndex() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $0.Timestamp get blockTime => $_getN(5);
+  @$pb.TagNumber(9)
+  set blockTime($0.Timestamp v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasBlockTime() => $_has(5);
+  @$pb.TagNumber(9)
+  void clearBlockTime() => clearField(9);
+  @$pb.TagNumber(9)
+  $0.Timestamp ensureBlockTime() => $_ensure(5);
+
+  @$pb.TagNumber(10)
+  $core.String get txid => $_getSZ(6);
+  @$pb.TagNumber(10)
+  set txid($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasTxid() => $_has(6);
+  @$pb.TagNumber(10)
+  void clearTxid() => clearField(10);
+
+  /// string witness_txid = 11;
+  @$pb.TagNumber(12)
+  $core.List<$core.String> get walletConflicts => $_getList(7);
+
+  @$pb.TagNumber(13)
+  $core.String get replacedByTxid => $_getSZ(8);
+  @$pb.TagNumber(13)
+  set replacedByTxid($core.String v) { $_setString(8, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasReplacedByTxid() => $_has(8);
+  @$pb.TagNumber(13)
+  void clearReplacedByTxid() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.String get replacesTxid => $_getSZ(9);
+  @$pb.TagNumber(14)
+  set replacesTxid($core.String v) { $_setString(9, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasReplacesTxid() => $_has(9);
+  @$pb.TagNumber(14)
+  void clearReplacesTxid() => clearField(14);
+
+  /// string comment = 15;
+  /// string to = 16;
+  @$pb.TagNumber(17)
+  $0.Timestamp get time => $_getN(10);
+  @$pb.TagNumber(17)
+  set time($0.Timestamp v) { setField(17, v); }
+  @$pb.TagNumber(17)
+  $core.bool hasTime() => $_has(10);
+  @$pb.TagNumber(17)
+  void clearTime() => clearField(17);
+  @$pb.TagNumber(17)
+  $0.Timestamp ensureTime() => $_ensure(10);
+
+  @$pb.TagNumber(18)
+  $0.Timestamp get timeReceived => $_getN(11);
+  @$pb.TagNumber(18)
+  set timeReceived($0.Timestamp v) { setField(18, v); }
+  @$pb.TagNumber(18)
+  $core.bool hasTimeReceived() => $_has(11);
+  @$pb.TagNumber(18)
+  void clearTimeReceived() => clearField(18);
+  @$pb.TagNumber(18)
+  $0.Timestamp ensureTimeReceived() => $_ensure(11);
+
+  ///  Whether this transaction signals BIP125 (Replace-by-fee, RBF) replaceability
+  ///  or has an unconfirmed ancestor signaling BIP125 replaceability. May be unspecified
+  ///  for unconfirmed transactions not in the mempool because their
+  ///  unconfirmed ancestors are unknown.
+  ///
+  ///  Note that this is always set to 'no' once the transaction is confirmed.
+  @$pb.TagNumber(19)
+  GetTransactionResponse_Replaceable get bip125Replaceable => $_getN(12);
+  @$pb.TagNumber(19)
+  set bip125Replaceable(GetTransactionResponse_Replaceable v) { setField(19, v); }
+  @$pb.TagNumber(19)
+  $core.bool hasBip125Replaceable() => $_has(12);
+  @$pb.TagNumber(19)
+  void clearBip125Replaceable() => clearField(19);
+
+  @$pb.TagNumber(21)
+  $core.List<GetTransactionResponse_Details> get details => $_getList(13);
+
+  @$pb.TagNumber(22)
+  $core.String get hex => $_getSZ(14);
+  @$pb.TagNumber(22)
+  set hex($core.String v) { $_setString(14, v); }
+  @$pb.TagNumber(22)
+  $core.bool hasHex() => $_has(14);
+  @$pb.TagNumber(22)
+  void clearHex() => clearField(22);
+}
+
+class GetRawTransactionRequest extends $pb.GeneratedMessage {
+  factory GetRawTransactionRequest({
+    $core.String? txid,
+    $core.bool? verbose,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (verbose != null) {
+      $result.verbose = verbose;
+    }
+    return $result;
+  }
+  GetRawTransactionRequest._() : super();
+  factory GetRawTransactionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetRawTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetRawTransactionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..aOB(2, _omitFieldNames ? '' : 'verbose')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetRawTransactionRequest clone() => GetRawTransactionRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetRawTransactionRequest copyWith(void Function(GetRawTransactionRequest) updates) => super.copyWith((message) => updates(message as GetRawTransactionRequest)) as GetRawTransactionRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetRawTransactionRequest create() => GetRawTransactionRequest._();
+  GetRawTransactionRequest createEmptyInstance() => create();
+  static $pb.PbList<GetRawTransactionRequest> createRepeated() => $pb.PbList<GetRawTransactionRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetRawTransactionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetRawTransactionRequest>(create);
+  static GetRawTransactionRequest? _defaultInstance;
+
+  /// The transaction ID. Required.
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  /// If false, returns just the hex string. Otherwise, returns the complete object.
+  @$pb.TagNumber(2)
+  $core.bool get verbose => $_getBF(1);
+  @$pb.TagNumber(2)
+  set verbose($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVerbose() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVerbose() => clearField(2);
+}
+
+class Input extends $pb.GeneratedMessage {
+  factory Input({
+    $core.String? txid,
+    $core.int? vout,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (vout != null) {
+      $result.vout = vout;
+    }
+    return $result;
+  }
+  Input._() : super();
+  factory Input.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Input.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Input', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'vout', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Input clone() => Input()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Input copyWith(void Function(Input) updates) => super.copyWith((message) => updates(message as Input)) as Input;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Input create() => Input._();
+  Input createEmptyInstance() => create();
+  static $pb.PbList<Input> createRepeated() => $pb.PbList<Input>();
+  @$core.pragma('dart2js:noInline')
+  static Input getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Input>(create);
+  static Input? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get vout => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set vout($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVout() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVout() => clearField(2);
+}
+
+class ScriptPubKey extends $pb.GeneratedMessage {
+  factory ScriptPubKey({
+    $core.String? type,
+    $core.String? address,
+  }) {
+    final $result = create();
+    if (type != null) {
+      $result.type = type;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    return $result;
+  }
+  ScriptPubKey._() : super();
+  factory ScriptPubKey.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ScriptPubKey.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ScriptPubKey', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'type')
+    ..aOS(2, _omitFieldNames ? '' : 'address')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ScriptPubKey clone() => ScriptPubKey()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ScriptPubKey copyWith(void Function(ScriptPubKey) updates) => super.copyWith((message) => updates(message as ScriptPubKey)) as ScriptPubKey;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ScriptPubKey create() => ScriptPubKey._();
+  ScriptPubKey createEmptyInstance() => create();
+  static $pb.PbList<ScriptPubKey> createRepeated() => $pb.PbList<ScriptPubKey>();
+  @$core.pragma('dart2js:noInline')
+  static ScriptPubKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ScriptPubKey>(create);
+  static ScriptPubKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get type => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set type($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasType() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearType() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get address => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set address($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAddress() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAddress() => clearField(2);
+}
+
+class Output extends $pb.GeneratedMessage {
+  factory Output({
+    $core.double? amount,
+    $core.int? n,
+    ScriptPubKey? scriptPubKey,
+  }) {
+    final $result = create();
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (n != null) {
+      $result.n = n;
+    }
+    if (scriptPubKey != null) {
+      $result.scriptPubKey = scriptPubKey;
+    }
+    return $result;
+  }
+  Output._() : super();
+  factory Output.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Output.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Output', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OD)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'n', $pb.PbFieldType.OU3)
+    ..aOM<ScriptPubKey>(3, _omitFieldNames ? '' : 'scriptPubKey', subBuilder: ScriptPubKey.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Output clone() => Output()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Output copyWith(void Function(Output) updates) => super.copyWith((message) => updates(message as Output)) as Output;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Output create() => Output._();
+  Output createEmptyInstance() => create();
+  static $pb.PbList<Output> createRepeated() => $pb.PbList<Output>();
+  @$core.pragma('dart2js:noInline')
+  static Output getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Output>(create);
+  static Output? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.double get amount => $_getN(0);
+  @$pb.TagNumber(1)
+  set amount($core.double v) { $_setDouble(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAmount() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAmount() => clearField(1);
+
+  /// The output index
+  @$pb.TagNumber(2)
+  $core.int get n => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set n($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasN() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearN() => clearField(2);
+
+  @$pb.TagNumber(3)
+  ScriptPubKey get scriptPubKey => $_getN(2);
+  @$pb.TagNumber(3)
+  set scriptPubKey(ScriptPubKey v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasScriptPubKey() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearScriptPubKey() => clearField(3);
+  @$pb.TagNumber(3)
+  ScriptPubKey ensureScriptPubKey() => $_ensure(2);
+}
+
+class GetRawTransactionResponse extends $pb.GeneratedMessage {
+  factory GetRawTransactionResponse({
+    RawTransaction? tx,
+    $core.Iterable<Input>? inputs,
+    $core.Iterable<Output>? outputs,
+    $core.String? blockhash,
+    $core.int? confirmations,
+    $fixnum.Int64? time,
+    $fixnum.Int64? blocktime,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    if (inputs != null) {
+      $result.inputs.addAll(inputs);
+    }
+    if (outputs != null) {
+      $result.outputs.addAll(outputs);
+    }
+    if (blockhash != null) {
+      $result.blockhash = blockhash;
+    }
+    if (confirmations != null) {
+      $result.confirmations = confirmations;
+    }
+    if (time != null) {
+      $result.time = time;
+    }
+    if (blocktime != null) {
+      $result.blocktime = blocktime;
+    }
+    return $result;
+  }
+  GetRawTransactionResponse._() : super();
+  factory GetRawTransactionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetRawTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetRawTransactionResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOM<RawTransaction>(1, _omitFieldNames ? '' : 'tx', subBuilder: RawTransaction.create)
+    ..pc<Input>(2, _omitFieldNames ? '' : 'inputs', $pb.PbFieldType.PM, subBuilder: Input.create)
+    ..pc<Output>(3, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: Output.create)
+    ..aOS(4, _omitFieldNames ? '' : 'blockhash')
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'confirmations', $pb.PbFieldType.OU3)
+    ..aInt64(6, _omitFieldNames ? '' : 'time')
+    ..aInt64(7, _omitFieldNames ? '' : 'blocktime')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetRawTransactionResponse clone() => GetRawTransactionResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetRawTransactionResponse copyWith(void Function(GetRawTransactionResponse) updates) => super.copyWith((message) => updates(message as GetRawTransactionResponse)) as GetRawTransactionResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetRawTransactionResponse create() => GetRawTransactionResponse._();
+  GetRawTransactionResponse createEmptyInstance() => create();
+  static $pb.PbList<GetRawTransactionResponse> createRepeated() => $pb.PbList<GetRawTransactionResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetRawTransactionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetRawTransactionResponse>(create);
+  static GetRawTransactionResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  RawTransaction get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(RawTransaction v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  RawTransaction ensureTx() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<Input> get inputs => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.List<Output> get outputs => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $core.String get blockhash => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set blockhash($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasBlockhash() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearBlockhash() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get confirmations => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set confirmations($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasConfirmations() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearConfirmations() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $fixnum.Int64 get time => $_getI64(5);
+  @$pb.TagNumber(6)
+  set time($fixnum.Int64 v) { $_setInt64(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasTime() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearTime() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $fixnum.Int64 get blocktime => $_getI64(6);
+  @$pb.TagNumber(7)
+  set blocktime($fixnum.Int64 v) { $_setInt64(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasBlocktime() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearBlocktime() => clearField(7);
+}
+
+class SendRequest extends $pb.GeneratedMessage {
+  factory SendRequest({
+    $core.Map<$core.String, $core.double>? destinations,
+    $core.int? confTarget,
+    $core.String? wallet,
+    $core.bool? includeUnsafe,
+    $core.Iterable<$core.String>? subtractFeeFromOutputs,
+    $1.BoolValue? addToWallet,
+    $core.double? feeRate,
+  }) {
+    final $result = create();
+    if (destinations != null) {
+      $result.destinations.addAll(destinations);
+    }
+    if (confTarget != null) {
+      $result.confTarget = confTarget;
+    }
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    if (includeUnsafe != null) {
+      $result.includeUnsafe = includeUnsafe;
+    }
+    if (subtractFeeFromOutputs != null) {
+      $result.subtractFeeFromOutputs.addAll(subtractFeeFromOutputs);
+    }
+    if (addToWallet != null) {
+      $result.addToWallet = addToWallet;
+    }
+    if (feeRate != null) {
+      $result.feeRate = feeRate;
+    }
+    return $result;
+  }
+  SendRequest._() : super();
+  factory SendRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SendRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..m<$core.String, $core.double>(1, _omitFieldNames ? '' : 'destinations', entryClassName: 'SendRequest.DestinationsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OD, packageName: const $pb.PackageName('bitcoin.bitcoind.v1alpha'))
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'confTarget', $pb.PbFieldType.OU3)
+    ..aOS(3, _omitFieldNames ? '' : 'wallet')
+    ..aOB(4, _omitFieldNames ? '' : 'includeUnsafe')
+    ..pPS(5, _omitFieldNames ? '' : 'subtractFeeFromOutputs')
+    ..aOM<$1.BoolValue>(6, _omitFieldNames ? '' : 'addToWallet', subBuilder: $1.BoolValue.create)
+    ..a<$core.double>(7, _omitFieldNames ? '' : 'feeRate', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SendRequest clone() => SendRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SendRequest copyWith(void Function(SendRequest) updates) => super.copyWith((message) => updates(message as SendRequest)) as SendRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SendRequest create() => SendRequest._();
+  SendRequest createEmptyInstance() => create();
+  static $pb.PbList<SendRequest> createRepeated() => $pb.PbList<SendRequest>();
+  @$core.pragma('dart2js:noInline')
+  static SendRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendRequest>(create);
+  static SendRequest? _defaultInstance;
+
+  /// bitcoin address -> BTC amount
+  @$pb.TagNumber(1)
+  $core.Map<$core.String, $core.double> get destinations => $_getMap(0);
+
+  /// Confirmation target in blocks.
+  @$pb.TagNumber(2)
+  $core.int get confTarget => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set confTarget($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasConfTarget() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearConfTarget() => clearField(2);
+
+  /// Only needs to be set if dealing with multiple wallets at the same time.
+  /// TODO: better suited as a header?
+  @$pb.TagNumber(3)
+  $core.String get wallet => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set wallet($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasWallet() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearWallet() => clearField(3);
+
+  /// Include inputs that are not safe to spend (unconfirmed transactions from
+  /// outside keys and unconfirmed replacement transactions.
+  @$pb.TagNumber(4)
+  $core.bool get includeUnsafe => $_getBF(3);
+  @$pb.TagNumber(4)
+  set includeUnsafe($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasIncludeUnsafe() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearIncludeUnsafe() => clearField(4);
+
+  /// Outouts to subtract the fee from, specified as as address from the
+  /// 'destinations' field. The fee will be equally deducted from the amount of
+  /// each specified output.
+  @$pb.TagNumber(5)
+  $core.List<$core.String> get subtractFeeFromOutputs => $_getList(4);
+
+  ///  When false, returns a serialized transaction which will not be added
+  ///  to the wallet or broadcast.
+  ///
+  ///  This is a 'bool value' instead of a plain bool. This is clunky to
+  ///  work with, but the alternative would have been to either:
+  ///
+  ///  1. Have this be a bool with the default value as the opposite of
+  ///     Bitcoin Core
+  ///  2. Rename the parameter to something else.
+  ///
+  ///  Both of these seem bad.
+  @$pb.TagNumber(6)
+  $1.BoolValue get addToWallet => $_getN(5);
+  @$pb.TagNumber(6)
+  set addToWallet($1.BoolValue v) { setField(6, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAddToWallet() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAddToWallet() => clearField(6);
+  @$pb.TagNumber(6)
+  $1.BoolValue ensureAddToWallet() => $_ensure(5);
+
+  /// Satoshis per virtual byte (sat/vB).
+  @$pb.TagNumber(7)
+  $core.double get feeRate => $_getN(6);
+  @$pb.TagNumber(7)
+  set feeRate($core.double v) { $_setDouble(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasFeeRate() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearFeeRate() => clearField(7);
+}
+
+class SendResponse extends $pb.GeneratedMessage {
+  factory SendResponse({
+    $core.String? txid,
+    $core.bool? complete,
+    RawTransaction? tx,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (complete != null) {
+      $result.complete = complete;
+    }
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  SendResponse._() : super();
+  factory SendResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SendResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..aOB(2, _omitFieldNames ? '' : 'complete')
+    ..aOM<RawTransaction>(3, _omitFieldNames ? '' : 'tx', subBuilder: RawTransaction.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SendResponse clone() => SendResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SendResponse copyWith(void Function(SendResponse) updates) => super.copyWith((message) => updates(message as SendResponse)) as SendResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SendResponse create() => SendResponse._();
+  SendResponse createEmptyInstance() => create();
+  static $pb.PbList<SendResponse> createRepeated() => $pb.PbList<SendResponse>();
+  @$core.pragma('dart2js:noInline')
+  static SendResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendResponse>(create);
+  static SendResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get complete => $_getBF(1);
+  @$pb.TagNumber(2)
+  set complete($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasComplete() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearComplete() => clearField(2);
+
+  /// If 'add_to_wallet' is false, the raw transaction with signature(s)
+  @$pb.TagNumber(3)
+  RawTransaction get tx => $_getN(2);
+  @$pb.TagNumber(3)
+  set tx(RawTransaction v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasTx() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTx() => clearField(3);
+  @$pb.TagNumber(3)
+  RawTransaction ensureTx() => $_ensure(2);
+}
+
+class SendToAddressRequest extends $pb.GeneratedMessage {
+  factory SendToAddressRequest({
+    $core.String? address,
+    $core.double? amount,
+    $core.String? comment,
+    $core.String? commentTo,
+    $core.String? wallet,
+  }) {
+    final $result = create();
+    if (address != null) {
+      $result.address = address;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (comment != null) {
+      $result.comment = comment;
+    }
+    if (commentTo != null) {
+      $result.commentTo = commentTo;
+    }
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    return $result;
+  }
+  SendToAddressRequest._() : super();
+  factory SendToAddressRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SendToAddressRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendToAddressRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'address')
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OD)
+    ..aOS(3, _omitFieldNames ? '' : 'comment')
+    ..aOS(4, _omitFieldNames ? '' : 'commentTo')
+    ..aOS(5, _omitFieldNames ? '' : 'wallet')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SendToAddressRequest clone() => SendToAddressRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SendToAddressRequest copyWith(void Function(SendToAddressRequest) updates) => super.copyWith((message) => updates(message as SendToAddressRequest)) as SendToAddressRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SendToAddressRequest create() => SendToAddressRequest._();
+  SendToAddressRequest createEmptyInstance() => create();
+  static $pb.PbList<SendToAddressRequest> createRepeated() => $pb.PbList<SendToAddressRequest>();
+  @$core.pragma('dart2js:noInline')
+  static SendToAddressRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendToAddressRequest>(create);
+  static SendToAddressRequest? _defaultInstance;
+
+  /// The bitcoin address to send to.
+  @$pb.TagNumber(1)
+  $core.String get address => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set address($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasAddress() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearAddress() => clearField(1);
+
+  /// The amount in BTC to send. eg 0.1
+  @$pb.TagNumber(2)
+  $core.double get amount => $_getN(1);
+  @$pb.TagNumber(2)
+  set amount($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmount() => clearField(2);
+
+  /// A comment used to store what the transaction is for. Not part of the transaction, just kept in your wallet.
+  @$pb.TagNumber(3)
+  $core.String get comment => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set comment($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasComment() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearComment() => clearField(3);
+
+  /// A comment to store the name of the person or organization to which you're sending the transaction. Not part of the transaction, just kept in your wallet.
+  @$pb.TagNumber(4)
+  $core.String get commentTo => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set commentTo($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCommentTo() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCommentTo() => clearField(4);
+
+  /// Only needs to be set if dealing with multiple wallets at the same time.
+  @$pb.TagNumber(5)
+  $core.String get wallet => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set wallet($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasWallet() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearWallet() => clearField(5);
+}
+
+class SendToAddressResponse extends $pb.GeneratedMessage {
+  factory SendToAddressResponse({
+    $core.String? txid,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    return $result;
+  }
+  SendToAddressResponse._() : super();
+  factory SendToAddressResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SendToAddressResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SendToAddressResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SendToAddressResponse clone() => SendToAddressResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SendToAddressResponse copyWith(void Function(SendToAddressResponse) updates) => super.copyWith((message) => updates(message as SendToAddressResponse)) as SendToAddressResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static SendToAddressResponse create() => SendToAddressResponse._();
+  SendToAddressResponse createEmptyInstance() => create();
+  static $pb.PbList<SendToAddressResponse> createRepeated() => $pb.PbList<SendToAddressResponse>();
+  @$core.pragma('dart2js:noInline')
+  static SendToAddressResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SendToAddressResponse>(create);
+  static SendToAddressResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+}
+
+class EstimateSmartFeeRequest extends $pb.GeneratedMessage {
+  factory EstimateSmartFeeRequest({
+    $fixnum.Int64? confTarget,
+    EstimateSmartFeeRequest_EstimateMode? estimateMode,
+  }) {
+    final $result = create();
+    if (confTarget != null) {
+      $result.confTarget = confTarget;
+    }
+    if (estimateMode != null) {
+      $result.estimateMode = estimateMode;
+    }
+    return $result;
+  }
+  EstimateSmartFeeRequest._() : super();
+  factory EstimateSmartFeeRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EstimateSmartFeeRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EstimateSmartFeeRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aInt64(1, _omitFieldNames ? '' : 'confTarget')
+    ..e<EstimateSmartFeeRequest_EstimateMode>(2, _omitFieldNames ? '' : 'estimateMode', $pb.PbFieldType.OE, defaultOrMaker: EstimateSmartFeeRequest_EstimateMode.ESTIMATE_MODE_UNSPECIFIED, valueOf: EstimateSmartFeeRequest_EstimateMode.valueOf, enumValues: EstimateSmartFeeRequest_EstimateMode.values)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EstimateSmartFeeRequest clone() => EstimateSmartFeeRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EstimateSmartFeeRequest copyWith(void Function(EstimateSmartFeeRequest) updates) => super.copyWith((message) => updates(message as EstimateSmartFeeRequest)) as EstimateSmartFeeRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EstimateSmartFeeRequest create() => EstimateSmartFeeRequest._();
+  EstimateSmartFeeRequest createEmptyInstance() => create();
+  static $pb.PbList<EstimateSmartFeeRequest> createRepeated() => $pb.PbList<EstimateSmartFeeRequest>();
+  @$core.pragma('dart2js:noInline')
+  static EstimateSmartFeeRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EstimateSmartFeeRequest>(create);
+  static EstimateSmartFeeRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get confTarget => $_getI64(0);
+  @$pb.TagNumber(1)
+  set confTarget($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasConfTarget() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearConfTarget() => clearField(1);
+
+  @$pb.TagNumber(2)
+  EstimateSmartFeeRequest_EstimateMode get estimateMode => $_getN(1);
+  @$pb.TagNumber(2)
+  set estimateMode(EstimateSmartFeeRequest_EstimateMode v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasEstimateMode() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearEstimateMode() => clearField(2);
+}
+
+class EstimateSmartFeeResponse extends $pb.GeneratedMessage {
+  factory EstimateSmartFeeResponse({
+    $core.double? feeRate,
+    $core.Iterable<$core.String>? errors,
+    $fixnum.Int64? blocks,
+  }) {
+    final $result = create();
+    if (feeRate != null) {
+      $result.feeRate = feeRate;
+    }
+    if (errors != null) {
+      $result.errors.addAll(errors);
+    }
+    if (blocks != null) {
+      $result.blocks = blocks;
+    }
+    return $result;
+  }
+  EstimateSmartFeeResponse._() : super();
+  factory EstimateSmartFeeResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory EstimateSmartFeeResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EstimateSmartFeeResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'feeRate', $pb.PbFieldType.OD)
+    ..pPS(2, _omitFieldNames ? '' : 'errors')
+    ..aInt64(3, _omitFieldNames ? '' : 'blocks')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  EstimateSmartFeeResponse clone() => EstimateSmartFeeResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  EstimateSmartFeeResponse copyWith(void Function(EstimateSmartFeeResponse) updates) => super.copyWith((message) => updates(message as EstimateSmartFeeResponse)) as EstimateSmartFeeResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static EstimateSmartFeeResponse create() => EstimateSmartFeeResponse._();
+  EstimateSmartFeeResponse createEmptyInstance() => create();
+  static $pb.PbList<EstimateSmartFeeResponse> createRepeated() => $pb.PbList<EstimateSmartFeeResponse>();
+  @$core.pragma('dart2js:noInline')
+  static EstimateSmartFeeResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EstimateSmartFeeResponse>(create);
+  static EstimateSmartFeeResponse? _defaultInstance;
+
+  /// Estimate fee rate in BTC/kvB (only present if no errors were encountered)
+  @$pb.TagNumber(1)
+  $core.double get feeRate => $_getN(0);
+  @$pb.TagNumber(1)
+  set feeRate($core.double v) { $_setDouble(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasFeeRate() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearFeeRate() => clearField(1);
+
+  /// Errors encountered during processing (if there are any)
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get errors => $_getList(1);
+
+  /// Block number where estimate was found.
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get blocks => $_getI64(2);
+  @$pb.TagNumber(3)
+  set blocks($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBlocks() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBlocks() => clearField(3);
+}
+
+class DecodeRawTransactionRequest extends $pb.GeneratedMessage {
+  factory DecodeRawTransactionRequest({
+    RawTransaction? tx,
+  }) {
+    final $result = create();
+    if (tx != null) {
+      $result.tx = tx;
+    }
+    return $result;
+  }
+  DecodeRawTransactionRequest._() : super();
+  factory DecodeRawTransactionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecodeRawTransactionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecodeRawTransactionRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOM<RawTransaction>(1, _omitFieldNames ? '' : 'tx', subBuilder: RawTransaction.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DecodeRawTransactionRequest clone() => DecodeRawTransactionRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecodeRawTransactionRequest copyWith(void Function(DecodeRawTransactionRequest) updates) => super.copyWith((message) => updates(message as DecodeRawTransactionRequest)) as DecodeRawTransactionRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DecodeRawTransactionRequest create() => DecodeRawTransactionRequest._();
+  DecodeRawTransactionRequest createEmptyInstance() => create();
+  static $pb.PbList<DecodeRawTransactionRequest> createRepeated() => $pb.PbList<DecodeRawTransactionRequest>();
+  @$core.pragma('dart2js:noInline')
+  static DecodeRawTransactionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecodeRawTransactionRequest>(create);
+  static DecodeRawTransactionRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  RawTransaction get tx => $_getN(0);
+  @$pb.TagNumber(1)
+  set tx(RawTransaction v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTx() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTx() => clearField(1);
+  @$pb.TagNumber(1)
+  RawTransaction ensureTx() => $_ensure(0);
+}
+
+class RawTransaction extends $pb.GeneratedMessage {
+  factory RawTransaction({
+    $core.List<$core.int>? data,
+    $core.String? hex,
+  }) {
+    final $result = create();
+    if (data != null) {
+      $result.data = data;
+    }
+    if (hex != null) {
+      $result.hex = hex;
+    }
+    return $result;
+  }
+  RawTransaction._() : super();
+  factory RawTransaction.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory RawTransaction.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'RawTransaction', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..aOS(2, _omitFieldNames ? '' : 'hex')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  RawTransaction clone() => RawTransaction()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  RawTransaction copyWith(void Function(RawTransaction) updates) => super.copyWith((message) => updates(message as RawTransaction)) as RawTransaction;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static RawTransaction create() => RawTransaction._();
+  RawTransaction createEmptyInstance() => create();
+  static $pb.PbList<RawTransaction> createRepeated() => $pb.PbList<RawTransaction>();
+  @$core.pragma('dart2js:noInline')
+  static RawTransaction getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<RawTransaction>(create);
+  static RawTransaction? _defaultInstance;
+
+  /// Raw transaction data
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get data => $_getN(0);
+  @$pb.TagNumber(1)
+  set data($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasData() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearData() => clearField(1);
+
+  /// Hex-encoded raw transaction data
+  @$pb.TagNumber(2)
+  $core.String get hex => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set hex($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHex() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHex() => clearField(2);
+}
+
+class DecodeRawTransactionResponse extends $pb.GeneratedMessage {
+  factory DecodeRawTransactionResponse({
+    $core.String? txid,
+    $core.String? hash,
+    $core.int? size,
+    $core.int? virtualSize,
+    $core.int? weight,
+    $core.int? version,
+    $core.int? locktime,
+    $core.Iterable<Input>? inputs,
+    $core.Iterable<Output>? outputs,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    if (size != null) {
+      $result.size = size;
+    }
+    if (virtualSize != null) {
+      $result.virtualSize = virtualSize;
+    }
+    if (weight != null) {
+      $result.weight = weight;
+    }
+    if (version != null) {
+      $result.version = version;
+    }
+    if (locktime != null) {
+      $result.locktime = locktime;
+    }
+    if (inputs != null) {
+      $result.inputs.addAll(inputs);
+    }
+    if (outputs != null) {
+      $result.outputs.addAll(outputs);
+    }
+    return $result;
+  }
+  DecodeRawTransactionResponse._() : super();
+  factory DecodeRawTransactionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DecodeRawTransactionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DecodeRawTransactionResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..aOS(2, _omitFieldNames ? '' : 'hash')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'size', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'virtualSize', $pb.PbFieldType.OU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'weight', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'version', $pb.PbFieldType.OU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'locktime', $pb.PbFieldType.OU3)
+    ..pc<Input>(8, _omitFieldNames ? '' : 'inputs', $pb.PbFieldType.PM, subBuilder: Input.create)
+    ..pc<Output>(9, _omitFieldNames ? '' : 'outputs', $pb.PbFieldType.PM, subBuilder: Output.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DecodeRawTransactionResponse clone() => DecodeRawTransactionResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DecodeRawTransactionResponse copyWith(void Function(DecodeRawTransactionResponse) updates) => super.copyWith((message) => updates(message as DecodeRawTransactionResponse)) as DecodeRawTransactionResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DecodeRawTransactionResponse create() => DecodeRawTransactionResponse._();
+  DecodeRawTransactionResponse createEmptyInstance() => create();
+  static $pb.PbList<DecodeRawTransactionResponse> createRepeated() => $pb.PbList<DecodeRawTransactionResponse>();
+  @$core.pragma('dart2js:noInline')
+  static DecodeRawTransactionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DecodeRawTransactionResponse>(create);
+  static DecodeRawTransactionResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get hash => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set hash($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+
+  /// The serialized transaction size
+  @$pb.TagNumber(3)
+  $core.int get size => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set size($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSize() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSize() => clearField(3);
+
+  /// The virtual transaction size (differs from
+  /// 'size' for witness transactions).
+  @$pb.TagNumber(4)
+  $core.int get virtualSize => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set virtualSize($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasVirtualSize() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearVirtualSize() => clearField(4);
+
+  /// The transaction's weight
+  @$pb.TagNumber(5)
+  $core.int get weight => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set weight($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasWeight() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearWeight() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get version => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set version($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasVersion() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearVersion() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get locktime => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set locktime($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasLocktime() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearLocktime() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.List<Input> get inputs => $_getList(7);
+
+  @$pb.TagNumber(9)
+  $core.List<Output> get outputs => $_getList(8);
+}
+
+class ImportDescriptorsRequest_Request extends $pb.GeneratedMessage {
+  factory ImportDescriptorsRequest_Request({
+    $core.String? descriptor,
+    $core.bool? active,
+    $core.int? rangeStart,
+    $core.int? rangeEnd,
+    $0.Timestamp? timestamp,
+    $core.bool? internal,
+    $core.String? label,
+  }) {
+    final $result = create();
+    if (descriptor != null) {
+      $result.descriptor = descriptor;
+    }
+    if (active != null) {
+      $result.active = active;
+    }
+    if (rangeStart != null) {
+      $result.rangeStart = rangeStart;
+    }
+    if (rangeEnd != null) {
+      $result.rangeEnd = rangeEnd;
+    }
+    if (timestamp != null) {
+      $result.timestamp = timestamp;
+    }
+    if (internal != null) {
+      $result.internal = internal;
+    }
+    if (label != null) {
+      $result.label = label;
+    }
+    return $result;
+  }
+  ImportDescriptorsRequest_Request._() : super();
+  factory ImportDescriptorsRequest_Request.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ImportDescriptorsRequest_Request.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ImportDescriptorsRequest.Request', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'descriptor')
+    ..aOB(2, _omitFieldNames ? '' : 'active')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'rangeStart', $pb.PbFieldType.OU3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'rangeEnd', $pb.PbFieldType.OU3)
+    ..aOM<$0.Timestamp>(5, _omitFieldNames ? '' : 'timestamp', subBuilder: $0.Timestamp.create)
+    ..aOB(6, _omitFieldNames ? '' : 'internal')
+    ..aOS(7, _omitFieldNames ? '' : 'label')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsRequest_Request clone() => ImportDescriptorsRequest_Request()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsRequest_Request copyWith(void Function(ImportDescriptorsRequest_Request) updates) => super.copyWith((message) => updates(message as ImportDescriptorsRequest_Request)) as ImportDescriptorsRequest_Request;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsRequest_Request create() => ImportDescriptorsRequest_Request._();
+  ImportDescriptorsRequest_Request createEmptyInstance() => create();
+  static $pb.PbList<ImportDescriptorsRequest_Request> createRepeated() => $pb.PbList<ImportDescriptorsRequest_Request>();
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsRequest_Request getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ImportDescriptorsRequest_Request>(create);
+  static ImportDescriptorsRequest_Request? _defaultInstance;
+
+  /// Descriptor to import
+  @$pb.TagNumber(1)
+  $core.String get descriptor => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set descriptor($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDescriptor() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDescriptor() => clearField(1);
+
+  /// Set this descriptor to be the active descriptor for the corresponding type/externality.
+  @$pb.TagNumber(2)
+  $core.bool get active => $_getBF(1);
+  @$pb.TagNumber(2)
+  set active($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasActive() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearActive() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get rangeStart => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set rangeStart($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasRangeStart() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearRangeStart() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get rangeEnd => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set rangeEnd($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasRangeEnd() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearRangeEnd() => clearField(4);
+
+  /// Nil passes 'now' to Bitcoin Core, which bypasses scanning.
+  @$pb.TagNumber(5)
+  $0.Timestamp get timestamp => $_getN(4);
+  @$pb.TagNumber(5)
+  set timestamp($0.Timestamp v) { setField(5, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasTimestamp() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearTimestamp() => clearField(5);
+  @$pb.TagNumber(5)
+  $0.Timestamp ensureTimestamp() => $_ensure(4);
+
+  /// Whether matching outputs should be treated as not incoming payments (e.g. change)
+  @$pb.TagNumber(6)
+  $core.bool get internal => $_getBF(5);
+  @$pb.TagNumber(6)
+  set internal($core.bool v) { $_setBool(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasInternal() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearInternal() => clearField(6);
+
+  /// Label to assign to the address, only allowed with internal = false. Disabled for ranged descriptors.
+  @$pb.TagNumber(7)
+  $core.String get label => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set label($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasLabel() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearLabel() => clearField(7);
+}
+
+class ImportDescriptorsRequest extends $pb.GeneratedMessage {
+  factory ImportDescriptorsRequest({
+    $core.String? wallet,
+    $core.Iterable<ImportDescriptorsRequest_Request>? requests,
+  }) {
+    final $result = create();
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    if (requests != null) {
+      $result.requests.addAll(requests);
+    }
+    return $result;
+  }
+  ImportDescriptorsRequest._() : super();
+  factory ImportDescriptorsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ImportDescriptorsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ImportDescriptorsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'wallet')
+    ..pc<ImportDescriptorsRequest_Request>(2, _omitFieldNames ? '' : 'requests', $pb.PbFieldType.PM, subBuilder: ImportDescriptorsRequest_Request.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsRequest clone() => ImportDescriptorsRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsRequest copyWith(void Function(ImportDescriptorsRequest) updates) => super.copyWith((message) => updates(message as ImportDescriptorsRequest)) as ImportDescriptorsRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsRequest create() => ImportDescriptorsRequest._();
+  ImportDescriptorsRequest createEmptyInstance() => create();
+  static $pb.PbList<ImportDescriptorsRequest> createRepeated() => $pb.PbList<ImportDescriptorsRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ImportDescriptorsRequest>(create);
+  static ImportDescriptorsRequest? _defaultInstance;
+
+  /// Only needs to be set if dealing with multiple wallets at the same time.
+  /// TODO: better suited as a header?
+  @$pb.TagNumber(1)
+  $core.String get wallet => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set wallet($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWallet() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWallet() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<ImportDescriptorsRequest_Request> get requests => $_getList(1);
+}
+
+class ImportDescriptorsResponse_Error extends $pb.GeneratedMessage {
+  factory ImportDescriptorsResponse_Error({
+    $core.int? code,
+    $core.String? message,
+  }) {
+    final $result = create();
+    if (code != null) {
+      $result.code = code;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    return $result;
+  }
+  ImportDescriptorsResponse_Error._() : super();
+  factory ImportDescriptorsResponse_Error.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ImportDescriptorsResponse_Error.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ImportDescriptorsResponse.Error', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'code', $pb.PbFieldType.O3)
+    ..aOS(2, _omitFieldNames ? '' : 'message')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsResponse_Error clone() => ImportDescriptorsResponse_Error()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsResponse_Error copyWith(void Function(ImportDescriptorsResponse_Error) updates) => super.copyWith((message) => updates(message as ImportDescriptorsResponse_Error)) as ImportDescriptorsResponse_Error;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsResponse_Error create() => ImportDescriptorsResponse_Error._();
+  ImportDescriptorsResponse_Error createEmptyInstance() => create();
+  static $pb.PbList<ImportDescriptorsResponse_Error> createRepeated() => $pb.PbList<ImportDescriptorsResponse_Error>();
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsResponse_Error getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ImportDescriptorsResponse_Error>(create);
+  static ImportDescriptorsResponse_Error? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get code => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set code($core.int v) { $_setSignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCode() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCode() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get message => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set message($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMessage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMessage() => clearField(2);
+}
+
+class ImportDescriptorsResponse_Response extends $pb.GeneratedMessage {
+  factory ImportDescriptorsResponse_Response({
+    $core.bool? success,
+    $core.Iterable<$core.String>? warnings,
+    ImportDescriptorsResponse_Error? error,
+  }) {
+    final $result = create();
+    if (success != null) {
+      $result.success = success;
+    }
+    if (warnings != null) {
+      $result.warnings.addAll(warnings);
+    }
+    if (error != null) {
+      $result.error = error;
+    }
+    return $result;
+  }
+  ImportDescriptorsResponse_Response._() : super();
+  factory ImportDescriptorsResponse_Response.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ImportDescriptorsResponse_Response.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ImportDescriptorsResponse.Response', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'success')
+    ..pPS(2, _omitFieldNames ? '' : 'warnings')
+    ..aOM<ImportDescriptorsResponse_Error>(3, _omitFieldNames ? '' : 'error', subBuilder: ImportDescriptorsResponse_Error.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsResponse_Response clone() => ImportDescriptorsResponse_Response()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsResponse_Response copyWith(void Function(ImportDescriptorsResponse_Response) updates) => super.copyWith((message) => updates(message as ImportDescriptorsResponse_Response)) as ImportDescriptorsResponse_Response;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsResponse_Response create() => ImportDescriptorsResponse_Response._();
+  ImportDescriptorsResponse_Response createEmptyInstance() => create();
+  static $pb.PbList<ImportDescriptorsResponse_Response> createRepeated() => $pb.PbList<ImportDescriptorsResponse_Response>();
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsResponse_Response getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ImportDescriptorsResponse_Response>(create);
+  static ImportDescriptorsResponse_Response? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get success => $_getBF(0);
+  @$pb.TagNumber(1)
+  set success($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSuccess() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSuccess() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get warnings => $_getList(1);
+
+  @$pb.TagNumber(3)
+  ImportDescriptorsResponse_Error get error => $_getN(2);
+  @$pb.TagNumber(3)
+  set error(ImportDescriptorsResponse_Error v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasError() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearError() => clearField(3);
+  @$pb.TagNumber(3)
+  ImportDescriptorsResponse_Error ensureError() => $_ensure(2);
+}
+
+class ImportDescriptorsResponse extends $pb.GeneratedMessage {
+  factory ImportDescriptorsResponse({
+    $core.Iterable<ImportDescriptorsResponse_Response>? responses,
+  }) {
+    final $result = create();
+    if (responses != null) {
+      $result.responses.addAll(responses);
+    }
+    return $result;
+  }
+  ImportDescriptorsResponse._() : super();
+  factory ImportDescriptorsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ImportDescriptorsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ImportDescriptorsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..pc<ImportDescriptorsResponse_Response>(1, _omitFieldNames ? '' : 'responses', $pb.PbFieldType.PM, subBuilder: ImportDescriptorsResponse_Response.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsResponse clone() => ImportDescriptorsResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ImportDescriptorsResponse copyWith(void Function(ImportDescriptorsResponse) updates) => super.copyWith((message) => updates(message as ImportDescriptorsResponse)) as ImportDescriptorsResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsResponse create() => ImportDescriptorsResponse._();
+  ImportDescriptorsResponse createEmptyInstance() => create();
+  static $pb.PbList<ImportDescriptorsResponse> createRepeated() => $pb.PbList<ImportDescriptorsResponse>();
+  @$core.pragma('dart2js:noInline')
+  static ImportDescriptorsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ImportDescriptorsResponse>(create);
+  static ImportDescriptorsResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<ImportDescriptorsResponse_Response> get responses => $_getList(0);
+}
+
+class GetDescriptorInfoRequest extends $pb.GeneratedMessage {
+  factory GetDescriptorInfoRequest({
+    $core.String? descriptor,
+  }) {
+    final $result = create();
+    if (descriptor != null) {
+      $result.descriptor = descriptor;
+    }
+    return $result;
+  }
+  GetDescriptorInfoRequest._() : super();
+  factory GetDescriptorInfoRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetDescriptorInfoRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetDescriptorInfoRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'descriptor')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetDescriptorInfoRequest clone() => GetDescriptorInfoRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetDescriptorInfoRequest copyWith(void Function(GetDescriptorInfoRequest) updates) => super.copyWith((message) => updates(message as GetDescriptorInfoRequest)) as GetDescriptorInfoRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetDescriptorInfoRequest create() => GetDescriptorInfoRequest._();
+  GetDescriptorInfoRequest createEmptyInstance() => create();
+  static $pb.PbList<GetDescriptorInfoRequest> createRepeated() => $pb.PbList<GetDescriptorInfoRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetDescriptorInfoRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetDescriptorInfoRequest>(create);
+  static GetDescriptorInfoRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get descriptor => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set descriptor($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDescriptor() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDescriptor() => clearField(1);
+}
+
+class GetDescriptorInfoResponse extends $pb.GeneratedMessage {
+  factory GetDescriptorInfoResponse({
+    $core.String? descriptor,
+    $core.String? checksum,
+    $core.bool? isRange,
+    $core.bool? isSolvable,
+    $core.bool? hasPrivateKeys,
+  }) {
+    final $result = create();
+    if (descriptor != null) {
+      $result.descriptor = descriptor;
+    }
+    if (checksum != null) {
+      $result.checksum = checksum;
+    }
+    if (isRange != null) {
+      $result.isRange = isRange;
+    }
+    if (isSolvable != null) {
+      $result.isSolvable = isSolvable;
+    }
+    if (hasPrivateKeys != null) {
+      $result.hasPrivateKeys = hasPrivateKeys;
+    }
+    return $result;
+  }
+  GetDescriptorInfoResponse._() : super();
+  factory GetDescriptorInfoResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetDescriptorInfoResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetDescriptorInfoResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'descriptor')
+    ..aOS(2, _omitFieldNames ? '' : 'checksum')
+    ..aOB(3, _omitFieldNames ? '' : 'isRange')
+    ..aOB(4, _omitFieldNames ? '' : 'isSolvable')
+    ..aOB(5, _omitFieldNames ? '' : 'hasPrivateKeys')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetDescriptorInfoResponse clone() => GetDescriptorInfoResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetDescriptorInfoResponse copyWith(void Function(GetDescriptorInfoResponse) updates) => super.copyWith((message) => updates(message as GetDescriptorInfoResponse)) as GetDescriptorInfoResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetDescriptorInfoResponse create() => GetDescriptorInfoResponse._();
+  GetDescriptorInfoResponse createEmptyInstance() => create();
+  static $pb.PbList<GetDescriptorInfoResponse> createRepeated() => $pb.PbList<GetDescriptorInfoResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetDescriptorInfoResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetDescriptorInfoResponse>(create);
+  static GetDescriptorInfoResponse? _defaultInstance;
+
+  /// The descriptor in canonical form, without private keys.
+  @$pb.TagNumber(1)
+  $core.String get descriptor => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set descriptor($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDescriptor() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDescriptor() => clearField(1);
+
+  /// The checksum for the input descriptor
+  @$pb.TagNumber(2)
+  $core.String get checksum => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set checksum($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasChecksum() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearChecksum() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.bool get isRange => $_getBF(2);
+  @$pb.TagNumber(3)
+  set isRange($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasIsRange() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearIsRange() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get isSolvable => $_getBF(3);
+  @$pb.TagNumber(4)
+  set isSolvable($core.bool v) { $_setBool(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasIsSolvable() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearIsSolvable() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.bool get hasPrivateKeys => $_getBF(4);
+  @$pb.TagNumber(5)
+  set hasPrivateKeys($core.bool v) { $_setBool(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasHasPrivateKeys() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearHasPrivateKeys() => clearField(5);
+}
+
+class GetBlockRequest extends $pb.GeneratedMessage {
+  factory GetBlockRequest({
+    $core.String? hash,
+    GetBlockRequest_Verbosity? verbosity,
+  }) {
+    final $result = create();
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    if (verbosity != null) {
+      $result.verbosity = verbosity;
+    }
+    return $result;
+  }
+  GetBlockRequest._() : super();
+  factory GetBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'hash')
+    ..e<GetBlockRequest_Verbosity>(2, _omitFieldNames ? '' : 'verbosity', $pb.PbFieldType.OE, defaultOrMaker: GetBlockRequest_Verbosity.VERBOSITY_UNSPECIFIED, valueOf: GetBlockRequest_Verbosity.valueOf, enumValues: GetBlockRequest_Verbosity.values)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest clone() => GetBlockRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockRequest copyWith(void Function(GetBlockRequest) updates) => super.copyWith((message) => updates(message as GetBlockRequest)) as GetBlockRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBlockRequest create() => GetBlockRequest._();
+  GetBlockRequest createEmptyInstance() => create();
+  static $pb.PbList<GetBlockRequest> createRepeated() => $pb.PbList<GetBlockRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockRequest>(create);
+  static GetBlockRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get hash => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set hash($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearHash() => clearField(1);
+
+  @$pb.TagNumber(2)
+  GetBlockRequest_Verbosity get verbosity => $_getN(1);
+  @$pb.TagNumber(2)
+  set verbosity(GetBlockRequest_Verbosity v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasVerbosity() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearVerbosity() => clearField(2);
+}
+
+class GetBlockResponse extends $pb.GeneratedMessage {
+  factory GetBlockResponse({
+    $core.String? hex,
+    $core.String? hash,
+    $core.int? confirmations,
+    $core.int? height,
+    $core.int? version,
+    $core.String? versionHex,
+    $core.String? merkleRoot,
+    $0.Timestamp? time,
+    $core.int? nonce,
+    $core.String? bits,
+    $core.double? difficulty,
+    $core.String? previousBlockHash,
+    $core.String? nextBlockHash,
+    $core.int? strippedSize,
+    $core.int? size,
+    $core.int? weight,
+    $core.Iterable<$core.String>? txids,
+  }) {
+    final $result = create();
+    if (hex != null) {
+      $result.hex = hex;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    if (confirmations != null) {
+      $result.confirmations = confirmations;
+    }
+    if (height != null) {
+      $result.height = height;
+    }
+    if (version != null) {
+      $result.version = version;
+    }
+    if (versionHex != null) {
+      $result.versionHex = versionHex;
+    }
+    if (merkleRoot != null) {
+      $result.merkleRoot = merkleRoot;
+    }
+    if (time != null) {
+      $result.time = time;
+    }
+    if (nonce != null) {
+      $result.nonce = nonce;
+    }
+    if (bits != null) {
+      $result.bits = bits;
+    }
+    if (difficulty != null) {
+      $result.difficulty = difficulty;
+    }
+    if (previousBlockHash != null) {
+      $result.previousBlockHash = previousBlockHash;
+    }
+    if (nextBlockHash != null) {
+      $result.nextBlockHash = nextBlockHash;
+    }
+    if (strippedSize != null) {
+      $result.strippedSize = strippedSize;
+    }
+    if (size != null) {
+      $result.size = size;
+    }
+    if (weight != null) {
+      $result.weight = weight;
+    }
+    if (txids != null) {
+      $result.txids.addAll(txids);
+    }
+    return $result;
+  }
+  GetBlockResponse._() : super();
+  factory GetBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'hex')
+    ..aOS(2, _omitFieldNames ? '' : 'hash')
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'confirmations', $pb.PbFieldType.O3)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'height', $pb.PbFieldType.OU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'version', $pb.PbFieldType.O3)
+    ..aOS(6, _omitFieldNames ? '' : 'versionHex')
+    ..aOS(7, _omitFieldNames ? '' : 'merkleRoot')
+    ..aOM<$0.Timestamp>(8, _omitFieldNames ? '' : 'time', subBuilder: $0.Timestamp.create)
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'nonce', $pb.PbFieldType.OU3)
+    ..aOS(10, _omitFieldNames ? '' : 'bits')
+    ..a<$core.double>(11, _omitFieldNames ? '' : 'difficulty', $pb.PbFieldType.OD)
+    ..aOS(12, _omitFieldNames ? '' : 'previousBlockHash')
+    ..aOS(13, _omitFieldNames ? '' : 'nextBlockHash')
+    ..a<$core.int>(14, _omitFieldNames ? '' : 'strippedSize', $pb.PbFieldType.O3)
+    ..a<$core.int>(15, _omitFieldNames ? '' : 'size', $pb.PbFieldType.O3)
+    ..a<$core.int>(16, _omitFieldNames ? '' : 'weight', $pb.PbFieldType.O3)
+    ..pPS(17, _omitFieldNames ? '' : 'txids')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse clone() => GetBlockResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockResponse copyWith(void Function(GetBlockResponse) updates) => super.copyWith((message) => updates(message as GetBlockResponse)) as GetBlockResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBlockResponse create() => GetBlockResponse._();
+  GetBlockResponse createEmptyInstance() => create();
+  static $pb.PbList<GetBlockResponse> createRepeated() => $pb.PbList<GetBlockResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockResponse>(create);
+  static GetBlockResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get hex => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set hex($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasHex() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearHex() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get hash => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set hash($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get confirmations => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set confirmations($core.int v) { $_setSignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasConfirmations() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearConfirmations() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get height => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set height($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasHeight() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearHeight() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get version => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set version($core.int v) { $_setSignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasVersion() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearVersion() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get versionHex => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set versionHex($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasVersionHex() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearVersionHex() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.String get merkleRoot => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set merkleRoot($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasMerkleRoot() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearMerkleRoot() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $0.Timestamp get time => $_getN(7);
+  @$pb.TagNumber(8)
+  set time($0.Timestamp v) { setField(8, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasTime() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearTime() => clearField(8);
+  @$pb.TagNumber(8)
+  $0.Timestamp ensureTime() => $_ensure(7);
+
+  @$pb.TagNumber(9)
+  $core.int get nonce => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set nonce($core.int v) { $_setUnsignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasNonce() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearNonce() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.String get bits => $_getSZ(9);
+  @$pb.TagNumber(10)
+  set bits($core.String v) { $_setString(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasBits() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearBits() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.double get difficulty => $_getN(10);
+  @$pb.TagNumber(11)
+  set difficulty($core.double v) { $_setDouble(10, v); }
+  @$pb.TagNumber(11)
+  $core.bool hasDifficulty() => $_has(10);
+  @$pb.TagNumber(11)
+  void clearDifficulty() => clearField(11);
+
+  /// Expected number of hashes required to produce the chain up to this block (in hex)
+  /// string chainwork = 12; // not in rpcclient
+  @$pb.TagNumber(12)
+  $core.String get previousBlockHash => $_getSZ(11);
+  @$pb.TagNumber(12)
+  set previousBlockHash($core.String v) { $_setString(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasPreviousBlockHash() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearPreviousBlockHash() => clearField(12);
+
+  @$pb.TagNumber(13)
+  $core.String get nextBlockHash => $_getSZ(12);
+  @$pb.TagNumber(13)
+  set nextBlockHash($core.String v) { $_setString(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasNextBlockHash() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearNextBlockHash() => clearField(13);
+
+  @$pb.TagNumber(14)
+  $core.int get strippedSize => $_getIZ(13);
+  @$pb.TagNumber(14)
+  set strippedSize($core.int v) { $_setSignedInt32(13, v); }
+  @$pb.TagNumber(14)
+  $core.bool hasStrippedSize() => $_has(13);
+  @$pb.TagNumber(14)
+  void clearStrippedSize() => clearField(14);
+
+  @$pb.TagNumber(15)
+  $core.int get size => $_getIZ(14);
+  @$pb.TagNumber(15)
+  set size($core.int v) { $_setSignedInt32(14, v); }
+  @$pb.TagNumber(15)
+  $core.bool hasSize() => $_has(14);
+  @$pb.TagNumber(15)
+  void clearSize() => clearField(15);
+
+  @$pb.TagNumber(16)
+  $core.int get weight => $_getIZ(15);
+  @$pb.TagNumber(16)
+  set weight($core.int v) { $_setSignedInt32(15, v); }
+  @$pb.TagNumber(16)
+  $core.bool hasWeight() => $_has(15);
+  @$pb.TagNumber(16)
+  void clearWeight() => clearField(16);
+
+  /// List of transactions in the block, by TXID.
+  @$pb.TagNumber(17)
+  $core.List<$core.String> get txids => $_getList(16);
+}
+
+class BumpFeeRequest extends $pb.GeneratedMessage {
+  factory BumpFeeRequest({
+    $core.String? wallet,
+    $core.String? txid,
+  }) {
+    final $result = create();
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    return $result;
+  }
+  BumpFeeRequest._() : super();
+  factory BumpFeeRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BumpFeeRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'wallet')
+    ..aOS(2, _omitFieldNames ? '' : 'txid')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BumpFeeRequest clone() => BumpFeeRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BumpFeeRequest copyWith(void Function(BumpFeeRequest) updates) => super.copyWith((message) => updates(message as BumpFeeRequest)) as BumpFeeRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BumpFeeRequest create() => BumpFeeRequest._();
+  BumpFeeRequest createEmptyInstance() => create();
+  static $pb.PbList<BumpFeeRequest> createRepeated() => $pb.PbList<BumpFeeRequest>();
+  @$core.pragma('dart2js:noInline')
+  static BumpFeeRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BumpFeeRequest>(create);
+  static BumpFeeRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get wallet => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set wallet($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWallet() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWallet() => clearField(1);
+
+  /// The TXID to be bumped
+  @$pb.TagNumber(2)
+  $core.String get txid => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set txid($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasTxid() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearTxid() => clearField(2);
+}
+
+class BumpFeeResponse extends $pb.GeneratedMessage {
+  factory BumpFeeResponse({
+    $core.String? txid,
+    $core.double? originalFee,
+    $core.double? newFee,
+    $core.Iterable<$core.String>? errors,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (originalFee != null) {
+      $result.originalFee = originalFee;
+    }
+    if (newFee != null) {
+      $result.newFee = newFee;
+    }
+    if (errors != null) {
+      $result.errors.addAll(errors);
+    }
+    return $result;
+  }
+  BumpFeeResponse._() : super();
+  factory BumpFeeResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BumpFeeResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BumpFeeResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'originalFee', $pb.PbFieldType.OD)
+    ..a<$core.double>(3, _omitFieldNames ? '' : 'newFee', $pb.PbFieldType.OD)
+    ..pPS(4, _omitFieldNames ? '' : 'errors')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BumpFeeResponse clone() => BumpFeeResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BumpFeeResponse copyWith(void Function(BumpFeeResponse) updates) => super.copyWith((message) => updates(message as BumpFeeResponse)) as BumpFeeResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BumpFeeResponse create() => BumpFeeResponse._();
+  BumpFeeResponse createEmptyInstance() => create();
+  static $pb.PbList<BumpFeeResponse> createRepeated() => $pb.PbList<BumpFeeResponse>();
+  @$core.pragma('dart2js:noInline')
+  static BumpFeeResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BumpFeeResponse>(create);
+  static BumpFeeResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.double get originalFee => $_getN(1);
+  @$pb.TagNumber(2)
+  set originalFee($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasOriginalFee() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearOriginalFee() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.double get newFee => $_getN(2);
+  @$pb.TagNumber(3)
+  set newFee($core.double v) { $_setDouble(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasNewFee() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNewFee() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.String> get errors => $_getList(3);
+}
+
+class ListSinceBlockRequest extends $pb.GeneratedMessage {
+  factory ListSinceBlockRequest({
+    $core.String? wallet,
+    $core.String? hash,
+  }) {
+    final $result = create();
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    return $result;
+  }
+  ListSinceBlockRequest._() : super();
+  factory ListSinceBlockRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListSinceBlockRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSinceBlockRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'wallet')
+    ..aOS(2, _omitFieldNames ? '' : 'hash')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ListSinceBlockRequest clone() => ListSinceBlockRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListSinceBlockRequest copyWith(void Function(ListSinceBlockRequest) updates) => super.copyWith((message) => updates(message as ListSinceBlockRequest)) as ListSinceBlockRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ListSinceBlockRequest create() => ListSinceBlockRequest._();
+  ListSinceBlockRequest createEmptyInstance() => create();
+  static $pb.PbList<ListSinceBlockRequest> createRepeated() => $pb.PbList<ListSinceBlockRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ListSinceBlockRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSinceBlockRequest>(create);
+  static ListSinceBlockRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get wallet => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set wallet($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWallet() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWallet() => clearField(1);
+
+  /// If set, the block hash to list transactions since, otherwise list all transactions.
+  @$pb.TagNumber(2)
+  $core.String get hash => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set hash($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasHash() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearHash() => clearField(2);
+}
+
+class ListSinceBlockResponse extends $pb.GeneratedMessage {
+  factory ListSinceBlockResponse({
+    $core.Iterable<GetTransactionResponse>? transactions,
+  }) {
+    final $result = create();
+    if (transactions != null) {
+      $result.transactions.addAll(transactions);
+    }
+    return $result;
+  }
+  ListSinceBlockResponse._() : super();
+  factory ListSinceBlockResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListSinceBlockResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListSinceBlockResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..pc<GetTransactionResponse>(1, _omitFieldNames ? '' : 'transactions', $pb.PbFieldType.PM, subBuilder: GetTransactionResponse.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ListSinceBlockResponse clone() => ListSinceBlockResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListSinceBlockResponse copyWith(void Function(ListSinceBlockResponse) updates) => super.copyWith((message) => updates(message as ListSinceBlockResponse)) as ListSinceBlockResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ListSinceBlockResponse create() => ListSinceBlockResponse._();
+  ListSinceBlockResponse createEmptyInstance() => create();
+  static $pb.PbList<ListSinceBlockResponse> createRepeated() => $pb.PbList<ListSinceBlockResponse>();
+  @$core.pragma('dart2js:noInline')
+  static ListSinceBlockResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListSinceBlockResponse>(create);
+  static ListSinceBlockResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GetTransactionResponse> get transactions => $_getList(0);
+}
+
+class GetRawMempoolRequest extends $pb.GeneratedMessage {
+  factory GetRawMempoolRequest({
+    $core.bool? verbose,
+  }) {
+    final $result = create();
+    if (verbose != null) {
+      $result.verbose = verbose;
+    }
+    return $result;
+  }
+  GetRawMempoolRequest._() : super();
+  factory GetRawMempoolRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetRawMempoolRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetRawMempoolRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOB(1, _omitFieldNames ? '' : 'verbose')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetRawMempoolRequest clone() => GetRawMempoolRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetRawMempoolRequest copyWith(void Function(GetRawMempoolRequest) updates) => super.copyWith((message) => updates(message as GetRawMempoolRequest)) as GetRawMempoolRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetRawMempoolRequest create() => GetRawMempoolRequest._();
+  GetRawMempoolRequest createEmptyInstance() => create();
+  static $pb.PbList<GetRawMempoolRequest> createRepeated() => $pb.PbList<GetRawMempoolRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetRawMempoolRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetRawMempoolRequest>(create);
+  static GetRawMempoolRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get verbose => $_getBF(0);
+  @$pb.TagNumber(1)
+  set verbose($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVerbose() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVerbose() => clearField(1);
+}
+
+/// All values are in whole bitcoins
+class MempoolEntry_Fees extends $pb.GeneratedMessage {
+  factory MempoolEntry_Fees({
+    $core.double? base,
+    $core.double? modified,
+    $core.double? ancestor,
+    $core.double? descendant,
+  }) {
+    final $result = create();
+    if (base != null) {
+      $result.base = base;
+    }
+    if (modified != null) {
+      $result.modified = modified;
+    }
+    if (ancestor != null) {
+      $result.ancestor = ancestor;
+    }
+    if (descendant != null) {
+      $result.descendant = descendant;
+    }
+    return $result;
+  }
+  MempoolEntry_Fees._() : super();
+  factory MempoolEntry_Fees.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MempoolEntry_Fees.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MempoolEntry.Fees', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'base', $pb.PbFieldType.OD)
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'modified', $pb.PbFieldType.OD)
+    ..a<$core.double>(3, _omitFieldNames ? '' : 'ancestor', $pb.PbFieldType.OD)
+    ..a<$core.double>(4, _omitFieldNames ? '' : 'descendant', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MempoolEntry_Fees clone() => MempoolEntry_Fees()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MempoolEntry_Fees copyWith(void Function(MempoolEntry_Fees) updates) => super.copyWith((message) => updates(message as MempoolEntry_Fees)) as MempoolEntry_Fees;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MempoolEntry_Fees create() => MempoolEntry_Fees._();
+  MempoolEntry_Fees createEmptyInstance() => create();
+  static $pb.PbList<MempoolEntry_Fees> createRepeated() => $pb.PbList<MempoolEntry_Fees>();
+  @$core.pragma('dart2js:noInline')
+  static MempoolEntry_Fees getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MempoolEntry_Fees>(create);
+  static MempoolEntry_Fees? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.double get base => $_getN(0);
+  @$pb.TagNumber(1)
+  set base($core.double v) { $_setDouble(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasBase() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearBase() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.double get modified => $_getN(1);
+  @$pb.TagNumber(2)
+  set modified($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasModified() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearModified() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.double get ancestor => $_getN(2);
+  @$pb.TagNumber(3)
+  set ancestor($core.double v) { $_setDouble(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAncestor() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAncestor() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.double get descendant => $_getN(3);
+  @$pb.TagNumber(4)
+  set descendant($core.double v) { $_setDouble(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDescendant() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDescendant() => clearField(4);
+}
+
+class MempoolEntry extends $pb.GeneratedMessage {
+  factory MempoolEntry({
+    $core.int? virtualSize,
+    $core.int? weight,
+    $0.Timestamp? time,
+    $core.int? descendantCount,
+    $core.int? descendantSize,
+    $core.int? ancestorCount,
+    $core.int? ancestorSize,
+    $core.String? witnessTxid,
+    MempoolEntry_Fees? fees,
+    $core.Iterable<$core.String>? depends,
+    $core.Iterable<$core.String>? spentBy,
+    $core.bool? bip125Replaceable,
+    $core.bool? unbroadcast,
+  }) {
+    final $result = create();
+    if (virtualSize != null) {
+      $result.virtualSize = virtualSize;
+    }
+    if (weight != null) {
+      $result.weight = weight;
+    }
+    if (time != null) {
+      $result.time = time;
+    }
+    if (descendantCount != null) {
+      $result.descendantCount = descendantCount;
+    }
+    if (descendantSize != null) {
+      $result.descendantSize = descendantSize;
+    }
+    if (ancestorCount != null) {
+      $result.ancestorCount = ancestorCount;
+    }
+    if (ancestorSize != null) {
+      $result.ancestorSize = ancestorSize;
+    }
+    if (witnessTxid != null) {
+      $result.witnessTxid = witnessTxid;
+    }
+    if (fees != null) {
+      $result.fees = fees;
+    }
+    if (depends != null) {
+      $result.depends.addAll(depends);
+    }
+    if (spentBy != null) {
+      $result.spentBy.addAll(spentBy);
+    }
+    if (bip125Replaceable != null) {
+      $result.bip125Replaceable = bip125Replaceable;
+    }
+    if (unbroadcast != null) {
+      $result.unbroadcast = unbroadcast;
+    }
+    return $result;
+  }
+  MempoolEntry._() : super();
+  factory MempoolEntry.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory MempoolEntry.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'MempoolEntry', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'virtualSize', $pb.PbFieldType.OU3)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'weight', $pb.PbFieldType.OU3)
+    ..aOM<$0.Timestamp>(3, _omitFieldNames ? '' : 'time', subBuilder: $0.Timestamp.create)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'descendantCount', $pb.PbFieldType.OU3)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'descendantSize', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'ancestorCount', $pb.PbFieldType.OU3)
+    ..a<$core.int>(7, _omitFieldNames ? '' : 'ancestorSize', $pb.PbFieldType.OU3)
+    ..aOS(8, _omitFieldNames ? '' : 'witnessTxid')
+    ..aOM<MempoolEntry_Fees>(9, _omitFieldNames ? '' : 'fees', subBuilder: MempoolEntry_Fees.create)
+    ..pPS(10, _omitFieldNames ? '' : 'depends')
+    ..pPS(11, _omitFieldNames ? '' : 'spentBy')
+    ..aOB(12, _omitFieldNames ? '' : 'bip125Replaceable')
+    ..aOB(13, _omitFieldNames ? '' : 'unbroadcast')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  MempoolEntry clone() => MempoolEntry()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  MempoolEntry copyWith(void Function(MempoolEntry) updates) => super.copyWith((message) => updates(message as MempoolEntry)) as MempoolEntry;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static MempoolEntry create() => MempoolEntry._();
+  MempoolEntry createEmptyInstance() => create();
+  static $pb.PbList<MempoolEntry> createRepeated() => $pb.PbList<MempoolEntry>();
+  @$core.pragma('dart2js:noInline')
+  static MempoolEntry getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<MempoolEntry>(create);
+  static MempoolEntry? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get virtualSize => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set virtualSize($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasVirtualSize() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearVirtualSize() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get weight => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set weight($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasWeight() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearWeight() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $0.Timestamp get time => $_getN(2);
+  @$pb.TagNumber(3)
+  set time($0.Timestamp v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasTime() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearTime() => clearField(3);
+  @$pb.TagNumber(3)
+  $0.Timestamp ensureTime() => $_ensure(2);
+
+  @$pb.TagNumber(4)
+  $core.int get descendantCount => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set descendantCount($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDescendantCount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDescendantCount() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.int get descendantSize => $_getIZ(4);
+  @$pb.TagNumber(5)
+  set descendantSize($core.int v) { $_setUnsignedInt32(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasDescendantSize() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearDescendantSize() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get ancestorCount => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set ancestorCount($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAncestorCount() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAncestorCount() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.int get ancestorSize => $_getIZ(6);
+  @$pb.TagNumber(7)
+  set ancestorSize($core.int v) { $_setUnsignedInt32(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasAncestorSize() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearAncestorSize() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get witnessTxid => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set witnessTxid($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasWitnessTxid() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearWitnessTxid() => clearField(8);
+
+  @$pb.TagNumber(9)
+  MempoolEntry_Fees get fees => $_getN(8);
+  @$pb.TagNumber(9)
+  set fees(MempoolEntry_Fees v) { setField(9, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasFees() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearFees() => clearField(9);
+  @$pb.TagNumber(9)
+  MempoolEntry_Fees ensureFees() => $_ensure(8);
+
+  @$pb.TagNumber(10)
+  $core.List<$core.String> get depends => $_getList(9);
+
+  @$pb.TagNumber(11)
+  $core.List<$core.String> get spentBy => $_getList(10);
+
+  @$pb.TagNumber(12)
+  $core.bool get bip125Replaceable => $_getBF(11);
+  @$pb.TagNumber(12)
+  set bip125Replaceable($core.bool v) { $_setBool(11, v); }
+  @$pb.TagNumber(12)
+  $core.bool hasBip125Replaceable() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearBip125Replaceable() => clearField(12);
+
+  /// A transaction is unbroadcast if initial broadcast not yet
+  /// acknowledged by any peers.
+  @$pb.TagNumber(13)
+  $core.bool get unbroadcast => $_getBF(12);
+  @$pb.TagNumber(13)
+  set unbroadcast($core.bool v) { $_setBool(12, v); }
+  @$pb.TagNumber(13)
+  $core.bool hasUnbroadcast() => $_has(12);
+  @$pb.TagNumber(13)
+  void clearUnbroadcast() => clearField(13);
+}
+
+class GetRawMempoolResponse extends $pb.GeneratedMessage {
+  factory GetRawMempoolResponse({
+    $core.Iterable<$core.String>? txids,
+    $core.Map<$core.String, MempoolEntry>? transactions,
+  }) {
+    final $result = create();
+    if (txids != null) {
+      $result.txids.addAll(txids);
+    }
+    if (transactions != null) {
+      $result.transactions.addAll(transactions);
+    }
+    return $result;
+  }
+  GetRawMempoolResponse._() : super();
+  factory GetRawMempoolResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetRawMempoolResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetRawMempoolResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..pPS(1, _omitFieldNames ? '' : 'txids')
+    ..m<$core.String, MempoolEntry>(2, _omitFieldNames ? '' : 'transactions', entryClassName: 'GetRawMempoolResponse.TransactionsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: MempoolEntry.create, valueDefaultOrMaker: MempoolEntry.getDefault, packageName: const $pb.PackageName('bitcoin.bitcoind.v1alpha'))
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetRawMempoolResponse clone() => GetRawMempoolResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetRawMempoolResponse copyWith(void Function(GetRawMempoolResponse) updates) => super.copyWith((message) => updates(message as GetRawMempoolResponse)) as GetRawMempoolResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetRawMempoolResponse create() => GetRawMempoolResponse._();
+  GetRawMempoolResponse createEmptyInstance() => create();
+  static $pb.PbList<GetRawMempoolResponse> createRepeated() => $pb.PbList<GetRawMempoolResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetRawMempoolResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetRawMempoolResponse>(create);
+  static GetRawMempoolResponse? _defaultInstance;
+
+  /// Only set if this is a non-verbose response
+  @$pb.TagNumber(1)
+  $core.List<$core.String> get txids => $_getList(0);
+
+  /// Only set if this is a verbose response
+  @$pb.TagNumber(2)
+  $core.Map<$core.String, MempoolEntry> get transactions => $_getMap(1);
+}
+
+class GetBlockHashRequest extends $pb.GeneratedMessage {
+  factory GetBlockHashRequest({
+    $core.int? height,
+  }) {
+    final $result = create();
+    if (height != null) {
+      $result.height = height;
+    }
+    return $result;
+  }
+  GetBlockHashRequest._() : super();
+  factory GetBlockHashRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockHashRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockHashRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'height', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBlockHashRequest clone() => GetBlockHashRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockHashRequest copyWith(void Function(GetBlockHashRequest) updates) => super.copyWith((message) => updates(message as GetBlockHashRequest)) as GetBlockHashRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBlockHashRequest create() => GetBlockHashRequest._();
+  GetBlockHashRequest createEmptyInstance() => create();
+  static $pb.PbList<GetBlockHashRequest> createRepeated() => $pb.PbList<GetBlockHashRequest>();
+  @$core.pragma('dart2js:noInline')
+  static GetBlockHashRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockHashRequest>(create);
+  static GetBlockHashRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get height => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set height($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasHeight() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearHeight() => clearField(1);
+}
+
+class GetBlockHashResponse extends $pb.GeneratedMessage {
+  factory GetBlockHashResponse({
+    $core.String? hash,
+  }) {
+    final $result = create();
+    if (hash != null) {
+      $result.hash = hash;
+    }
+    return $result;
+  }
+  GetBlockHashResponse._() : super();
+  factory GetBlockHashResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GetBlockHashResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetBlockHashResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'hash')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GetBlockHashResponse clone() => GetBlockHashResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GetBlockHashResponse copyWith(void Function(GetBlockHashResponse) updates) => super.copyWith((message) => updates(message as GetBlockHashResponse)) as GetBlockHashResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetBlockHashResponse create() => GetBlockHashResponse._();
+  GetBlockHashResponse createEmptyInstance() => create();
+  static $pb.PbList<GetBlockHashResponse> createRepeated() => $pb.PbList<GetBlockHashResponse>();
+  @$core.pragma('dart2js:noInline')
+  static GetBlockHashResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetBlockHashResponse>(create);
+  static GetBlockHashResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get hash => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set hash($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasHash() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearHash() => clearField(1);
+}
+
+class ListTransactionsRequest extends $pb.GeneratedMessage {
+  factory ListTransactionsRequest({
+    $core.String? wallet,
+    $core.int? count,
+    $core.int? skip,
+  }) {
+    final $result = create();
+    if (wallet != null) {
+      $result.wallet = wallet;
+    }
+    if (count != null) {
+      $result.count = count;
+    }
+    if (skip != null) {
+      $result.skip = skip;
+    }
+    return $result;
+  }
+  ListTransactionsRequest._() : super();
+  factory ListTransactionsRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListTransactionsRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListTransactionsRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'wallet')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'count', $pb.PbFieldType.OU3)
+    ..a<$core.int>(3, _omitFieldNames ? '' : 'skip', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ListTransactionsRequest clone() => ListTransactionsRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListTransactionsRequest copyWith(void Function(ListTransactionsRequest) updates) => super.copyWith((message) => updates(message as ListTransactionsRequest)) as ListTransactionsRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ListTransactionsRequest create() => ListTransactionsRequest._();
+  ListTransactionsRequest createEmptyInstance() => create();
+  static $pb.PbList<ListTransactionsRequest> createRepeated() => $pb.PbList<ListTransactionsRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ListTransactionsRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListTransactionsRequest>(create);
+  static ListTransactionsRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get wallet => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set wallet($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasWallet() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWallet() => clearField(1);
+
+  /// Defaults to 10
+  @$pb.TagNumber(2)
+  $core.int get count => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set count($core.int v) { $_setUnsignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCount() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get skip => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set skip($core.int v) { $_setUnsignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSkip() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSkip() => clearField(3);
+}
+
+class ListTransactionsResponse extends $pb.GeneratedMessage {
+  factory ListTransactionsResponse({
+    $core.Iterable<GetTransactionResponse>? transactions,
+  }) {
+    final $result = create();
+    if (transactions != null) {
+      $result.transactions.addAll(transactions);
+    }
+    return $result;
+  }
+  ListTransactionsResponse._() : super();
+  factory ListTransactionsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListTransactionsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListTransactionsResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.bitcoind.v1alpha'), createEmptyInstance: create)
+    ..pc<GetTransactionResponse>(1, _omitFieldNames ? '' : 'transactions', $pb.PbFieldType.PM, subBuilder: GetTransactionResponse.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ListTransactionsResponse clone() => ListTransactionsResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListTransactionsResponse copyWith(void Function(ListTransactionsResponse) updates) => super.copyWith((message) => updates(message as ListTransactionsResponse)) as ListTransactionsResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ListTransactionsResponse create() => ListTransactionsResponse._();
+  ListTransactionsResponse createEmptyInstance() => create();
+  static $pb.PbList<ListTransactionsResponse> createRepeated() => $pb.PbList<ListTransactionsResponse>();
+  @$core.pragma('dart2js:noInline')
+  static ListTransactionsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListTransactionsResponse>(create);
+  static ListTransactionsResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GetTransactionResponse> get transactions => $_getList(0);
+}
+
+class BitcoinServiceApi {
+  $pb.RpcClient _client;
+  BitcoinServiceApi(this._client);
+
+  $async.Future<GetBlockchainInfoResponse> getBlockchainInfo($pb.ClientContext? ctx, GetBlockchainInfoRequest request) =>
+    _client.invoke<GetBlockchainInfoResponse>(ctx, 'BitcoinService', 'GetBlockchainInfo', request, GetBlockchainInfoResponse())
+  ;
+  $async.Future<GetTransactionResponse> getTransaction($pb.ClientContext? ctx, GetTransactionRequest request) =>
+    _client.invoke<GetTransactionResponse>(ctx, 'BitcoinService', 'GetTransaction', request, GetTransactionResponse())
+  ;
+  $async.Future<ListSinceBlockResponse> listSinceBlock($pb.ClientContext? ctx, ListSinceBlockRequest request) =>
+    _client.invoke<ListSinceBlockResponse>(ctx, 'BitcoinService', 'ListSinceBlock', request, ListSinceBlockResponse())
+  ;
+  $async.Future<GetNewAddressResponse> getNewAddress($pb.ClientContext? ctx, GetNewAddressRequest request) =>
+    _client.invoke<GetNewAddressResponse>(ctx, 'BitcoinService', 'GetNewAddress', request, GetNewAddressResponse())
+  ;
+  $async.Future<GetWalletInfoResponse> getWalletInfo($pb.ClientContext? ctx, GetWalletInfoRequest request) =>
+    _client.invoke<GetWalletInfoResponse>(ctx, 'BitcoinService', 'GetWalletInfo', request, GetWalletInfoResponse())
+  ;
+  $async.Future<GetBalancesResponse> getBalances($pb.ClientContext? ctx, GetBalancesRequest request) =>
+    _client.invoke<GetBalancesResponse>(ctx, 'BitcoinService', 'GetBalances', request, GetBalancesResponse())
+  ;
+  $async.Future<SendResponse> send($pb.ClientContext? ctx, SendRequest request) =>
+    _client.invoke<SendResponse>(ctx, 'BitcoinService', 'Send', request, SendResponse())
+  ;
+  $async.Future<SendToAddressResponse> sendToAddress($pb.ClientContext? ctx, SendToAddressRequest request) =>
+    _client.invoke<SendToAddressResponse>(ctx, 'BitcoinService', 'SendToAddress', request, SendToAddressResponse())
+  ;
+  $async.Future<BumpFeeResponse> bumpFee($pb.ClientContext? ctx, BumpFeeRequest request) =>
+    _client.invoke<BumpFeeResponse>(ctx, 'BitcoinService', 'BumpFee', request, BumpFeeResponse())
+  ;
+  $async.Future<EstimateSmartFeeResponse> estimateSmartFee($pb.ClientContext? ctx, EstimateSmartFeeRequest request) =>
+    _client.invoke<EstimateSmartFeeResponse>(ctx, 'BitcoinService', 'EstimateSmartFee', request, EstimateSmartFeeResponse())
+  ;
+  $async.Future<ImportDescriptorsResponse> importDescriptors($pb.ClientContext? ctx, ImportDescriptorsRequest request) =>
+    _client.invoke<ImportDescriptorsResponse>(ctx, 'BitcoinService', 'ImportDescriptors', request, ImportDescriptorsResponse())
+  ;
+  $async.Future<ListTransactionsResponse> listTransactions($pb.ClientContext? ctx, ListTransactionsRequest request) =>
+    _client.invoke<ListTransactionsResponse>(ctx, 'BitcoinService', 'ListTransactions', request, ListTransactionsResponse())
+  ;
+  $async.Future<GetDescriptorInfoResponse> getDescriptorInfo($pb.ClientContext? ctx, GetDescriptorInfoRequest request) =>
+    _client.invoke<GetDescriptorInfoResponse>(ctx, 'BitcoinService', 'GetDescriptorInfo', request, GetDescriptorInfoResponse())
+  ;
+  $async.Future<GetRawMempoolResponse> getRawMempool($pb.ClientContext? ctx, GetRawMempoolRequest request) =>
+    _client.invoke<GetRawMempoolResponse>(ctx, 'BitcoinService', 'GetRawMempool', request, GetRawMempoolResponse())
+  ;
+  $async.Future<GetRawTransactionResponse> getRawTransaction($pb.ClientContext? ctx, GetRawTransactionRequest request) =>
+    _client.invoke<GetRawTransactionResponse>(ctx, 'BitcoinService', 'GetRawTransaction', request, GetRawTransactionResponse())
+  ;
+  $async.Future<DecodeRawTransactionResponse> decodeRawTransaction($pb.ClientContext? ctx, DecodeRawTransactionRequest request) =>
+    _client.invoke<DecodeRawTransactionResponse>(ctx, 'BitcoinService', 'DecodeRawTransaction', request, DecodeRawTransactionResponse())
+  ;
+  $async.Future<GetBlockResponse> getBlock($pb.ClientContext? ctx, GetBlockRequest request) =>
+    _client.invoke<GetBlockResponse>(ctx, 'BitcoinService', 'GetBlock', request, GetBlockResponse())
+  ;
+  $async.Future<GetBlockHashResponse> getBlockHash($pb.ClientContext? ctx, GetBlockHashRequest request) =>
+    _client.invoke<GetBlockHashResponse>(ctx, 'BitcoinService', 'GetBlockHash', request, GetBlockHashResponse())
+  ;
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbenum.dart
+++ b/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbenum.dart
@@ -1,0 +1,95 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/bitcoind/v1alpha/bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class GetTransactionResponse_Replaceable extends $pb.ProtobufEnum {
+  static const GetTransactionResponse_Replaceable REPLACEABLE_UNSPECIFIED = GetTransactionResponse_Replaceable._(0, _omitEnumNames ? '' : 'REPLACEABLE_UNSPECIFIED');
+  static const GetTransactionResponse_Replaceable REPLACEABLE_YES = GetTransactionResponse_Replaceable._(1, _omitEnumNames ? '' : 'REPLACEABLE_YES');
+  static const GetTransactionResponse_Replaceable REPLACEABLE_NO = GetTransactionResponse_Replaceable._(2, _omitEnumNames ? '' : 'REPLACEABLE_NO');
+
+  static const $core.List<GetTransactionResponse_Replaceable> values = <GetTransactionResponse_Replaceable> [
+    REPLACEABLE_UNSPECIFIED,
+    REPLACEABLE_YES,
+    REPLACEABLE_NO,
+  ];
+
+  static final $core.Map<$core.int, GetTransactionResponse_Replaceable> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static GetTransactionResponse_Replaceable? valueOf($core.int value) => _byValue[value];
+
+  const GetTransactionResponse_Replaceable._($core.int v, $core.String n) : super(v, n);
+}
+
+class GetTransactionResponse_Category extends $pb.ProtobufEnum {
+  static const GetTransactionResponse_Category CATEGORY_UNSPECIFIED = GetTransactionResponse_Category._(0, _omitEnumNames ? '' : 'CATEGORY_UNSPECIFIED');
+  static const GetTransactionResponse_Category CATEGORY_SEND = GetTransactionResponse_Category._(1, _omitEnumNames ? '' : 'CATEGORY_SEND');
+  static const GetTransactionResponse_Category CATEGORY_RECEIVE = GetTransactionResponse_Category._(2, _omitEnumNames ? '' : 'CATEGORY_RECEIVE');
+  static const GetTransactionResponse_Category CATEGORY_GENERATE = GetTransactionResponse_Category._(3, _omitEnumNames ? '' : 'CATEGORY_GENERATE');
+  static const GetTransactionResponse_Category CATEGORY_IMMATURE = GetTransactionResponse_Category._(4, _omitEnumNames ? '' : 'CATEGORY_IMMATURE');
+  static const GetTransactionResponse_Category CATEGORY_ORPHAN = GetTransactionResponse_Category._(5, _omitEnumNames ? '' : 'CATEGORY_ORPHAN');
+
+  static const $core.List<GetTransactionResponse_Category> values = <GetTransactionResponse_Category> [
+    CATEGORY_UNSPECIFIED,
+    CATEGORY_SEND,
+    CATEGORY_RECEIVE,
+    CATEGORY_GENERATE,
+    CATEGORY_IMMATURE,
+    CATEGORY_ORPHAN,
+  ];
+
+  static final $core.Map<$core.int, GetTransactionResponse_Category> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static GetTransactionResponse_Category? valueOf($core.int value) => _byValue[value];
+
+  const GetTransactionResponse_Category._($core.int v, $core.String n) : super(v, n);
+}
+
+class EstimateSmartFeeRequest_EstimateMode extends $pb.ProtobufEnum {
+  static const EstimateSmartFeeRequest_EstimateMode ESTIMATE_MODE_UNSPECIFIED = EstimateSmartFeeRequest_EstimateMode._(0, _omitEnumNames ? '' : 'ESTIMATE_MODE_UNSPECIFIED');
+  static const EstimateSmartFeeRequest_EstimateMode ESTIMATE_MODE_ECONOMICAL = EstimateSmartFeeRequest_EstimateMode._(1, _omitEnumNames ? '' : 'ESTIMATE_MODE_ECONOMICAL');
+  static const EstimateSmartFeeRequest_EstimateMode ESTIMATE_MODE_CONSERVATIVE = EstimateSmartFeeRequest_EstimateMode._(2, _omitEnumNames ? '' : 'ESTIMATE_MODE_CONSERVATIVE');
+
+  static const $core.List<EstimateSmartFeeRequest_EstimateMode> values = <EstimateSmartFeeRequest_EstimateMode> [
+    ESTIMATE_MODE_UNSPECIFIED,
+    ESTIMATE_MODE_ECONOMICAL,
+    ESTIMATE_MODE_CONSERVATIVE,
+  ];
+
+  static final $core.Map<$core.int, EstimateSmartFeeRequest_EstimateMode> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static EstimateSmartFeeRequest_EstimateMode? valueOf($core.int value) => _byValue[value];
+
+  const EstimateSmartFeeRequest_EstimateMode._($core.int v, $core.String n) : super(v, n);
+}
+
+class GetBlockRequest_Verbosity extends $pb.ProtobufEnum {
+  static const GetBlockRequest_Verbosity VERBOSITY_UNSPECIFIED = GetBlockRequest_Verbosity._(0, _omitEnumNames ? '' : 'VERBOSITY_UNSPECIFIED');
+  static const GetBlockRequest_Verbosity VERBOSITY_RAW_DATA = GetBlockRequest_Verbosity._(1, _omitEnumNames ? '' : 'VERBOSITY_RAW_DATA');
+  static const GetBlockRequest_Verbosity VERBOSITY_BLOCK_INFO = GetBlockRequest_Verbosity._(2, _omitEnumNames ? '' : 'VERBOSITY_BLOCK_INFO');
+  static const GetBlockRequest_Verbosity VERBOSITY_BLOCK_TX_INFO = GetBlockRequest_Verbosity._(3, _omitEnumNames ? '' : 'VERBOSITY_BLOCK_TX_INFO');
+  static const GetBlockRequest_Verbosity VERBOSITY_BLOCK_TX_PREVOUT_INFO = GetBlockRequest_Verbosity._(4, _omitEnumNames ? '' : 'VERBOSITY_BLOCK_TX_PREVOUT_INFO');
+
+  static const $core.List<GetBlockRequest_Verbosity> values = <GetBlockRequest_Verbosity> [
+    VERBOSITY_UNSPECIFIED,
+    VERBOSITY_RAW_DATA,
+    VERBOSITY_BLOCK_INFO,
+    VERBOSITY_BLOCK_TX_INFO,
+    VERBOSITY_BLOCK_TX_PREVOUT_INFO,
+  ];
+
+  static final $core.Map<$core.int, GetBlockRequest_Verbosity> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static GetBlockRequest_Verbosity? valueOf($core.int value) => _byValue[value];
+
+  const GetBlockRequest_Verbosity._($core.int v, $core.String n) : super(v, n);
+}
+
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbgrpc.dart
+++ b/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbgrpc.dart
@@ -1,0 +1,399 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/bitcoind/v1alpha/bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:async' as $async;
+import 'dart:core' as $core;
+
+import 'package:grpc/service_api.dart' as $grpc;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'bitcoin.pb.dart' as $0;
+
+export 'bitcoin.pb.dart';
+
+@$pb.GrpcServiceName('bitcoin.bitcoind.v1alpha.BitcoinService')
+class BitcoinServiceClient extends $grpc.Client {
+  static final _$getBlockchainInfo = $grpc.ClientMethod<$0.GetBlockchainInfoRequest, $0.GetBlockchainInfoResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetBlockchainInfo',
+      ($0.GetBlockchainInfoRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetBlockchainInfoResponse.fromBuffer(value));
+  static final _$getTransaction = $grpc.ClientMethod<$0.GetTransactionRequest, $0.GetTransactionResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetTransaction',
+      ($0.GetTransactionRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetTransactionResponse.fromBuffer(value));
+  static final _$listSinceBlock = $grpc.ClientMethod<$0.ListSinceBlockRequest, $0.ListSinceBlockResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/ListSinceBlock',
+      ($0.ListSinceBlockRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ListSinceBlockResponse.fromBuffer(value));
+  static final _$getNewAddress = $grpc.ClientMethod<$0.GetNewAddressRequest, $0.GetNewAddressResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetNewAddress',
+      ($0.GetNewAddressRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetNewAddressResponse.fromBuffer(value));
+  static final _$getWalletInfo = $grpc.ClientMethod<$0.GetWalletInfoRequest, $0.GetWalletInfoResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetWalletInfo',
+      ($0.GetWalletInfoRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetWalletInfoResponse.fromBuffer(value));
+  static final _$getBalances = $grpc.ClientMethod<$0.GetBalancesRequest, $0.GetBalancesResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetBalances',
+      ($0.GetBalancesRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetBalancesResponse.fromBuffer(value));
+  static final _$send = $grpc.ClientMethod<$0.SendRequest, $0.SendResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/Send',
+      ($0.SendRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.SendResponse.fromBuffer(value));
+  static final _$sendToAddress = $grpc.ClientMethod<$0.SendToAddressRequest, $0.SendToAddressResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/SendToAddress',
+      ($0.SendToAddressRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.SendToAddressResponse.fromBuffer(value));
+  static final _$bumpFee = $grpc.ClientMethod<$0.BumpFeeRequest, $0.BumpFeeResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/BumpFee',
+      ($0.BumpFeeRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.BumpFeeResponse.fromBuffer(value));
+  static final _$estimateSmartFee = $grpc.ClientMethod<$0.EstimateSmartFeeRequest, $0.EstimateSmartFeeResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/EstimateSmartFee',
+      ($0.EstimateSmartFeeRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.EstimateSmartFeeResponse.fromBuffer(value));
+  static final _$importDescriptors = $grpc.ClientMethod<$0.ImportDescriptorsRequest, $0.ImportDescriptorsResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/ImportDescriptors',
+      ($0.ImportDescriptorsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ImportDescriptorsResponse.fromBuffer(value));
+  static final _$listTransactions = $grpc.ClientMethod<$0.ListTransactionsRequest, $0.ListTransactionsResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/ListTransactions',
+      ($0.ListTransactionsRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ListTransactionsResponse.fromBuffer(value));
+  static final _$getDescriptorInfo = $grpc.ClientMethod<$0.GetDescriptorInfoRequest, $0.GetDescriptorInfoResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetDescriptorInfo',
+      ($0.GetDescriptorInfoRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetDescriptorInfoResponse.fromBuffer(value));
+  static final _$getRawMempool = $grpc.ClientMethod<$0.GetRawMempoolRequest, $0.GetRawMempoolResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetRawMempool',
+      ($0.GetRawMempoolRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetRawMempoolResponse.fromBuffer(value));
+  static final _$getRawTransaction = $grpc.ClientMethod<$0.GetRawTransactionRequest, $0.GetRawTransactionResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetRawTransaction',
+      ($0.GetRawTransactionRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetRawTransactionResponse.fromBuffer(value));
+  static final _$decodeRawTransaction = $grpc.ClientMethod<$0.DecodeRawTransactionRequest, $0.DecodeRawTransactionResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/DecodeRawTransaction',
+      ($0.DecodeRawTransactionRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.DecodeRawTransactionResponse.fromBuffer(value));
+  static final _$getBlock = $grpc.ClientMethod<$0.GetBlockRequest, $0.GetBlockResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetBlock',
+      ($0.GetBlockRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetBlockResponse.fromBuffer(value));
+  static final _$getBlockHash = $grpc.ClientMethod<$0.GetBlockHashRequest, $0.GetBlockHashResponse>(
+      '/bitcoin.bitcoind.v1alpha.BitcoinService/GetBlockHash',
+      ($0.GetBlockHashRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.GetBlockHashResponse.fromBuffer(value));
+
+  BitcoinServiceClient($grpc.ClientChannel channel,
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      : super(channel, options: options,
+        interceptors: interceptors);
+
+  $grpc.ResponseFuture<$0.GetBlockchainInfoResponse> getBlockchainInfo($0.GetBlockchainInfoRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getBlockchainInfo, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetTransactionResponse> getTransaction($0.GetTransactionRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getTransaction, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.ListSinceBlockResponse> listSinceBlock($0.ListSinceBlockRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$listSinceBlock, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetNewAddressResponse> getNewAddress($0.GetNewAddressRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getNewAddress, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetWalletInfoResponse> getWalletInfo($0.GetWalletInfoRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getWalletInfo, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetBalancesResponse> getBalances($0.GetBalancesRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getBalances, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.SendResponse> send($0.SendRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$send, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.SendToAddressResponse> sendToAddress($0.SendToAddressRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$sendToAddress, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.BumpFeeResponse> bumpFee($0.BumpFeeRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$bumpFee, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.EstimateSmartFeeResponse> estimateSmartFee($0.EstimateSmartFeeRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$estimateSmartFee, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.ImportDescriptorsResponse> importDescriptors($0.ImportDescriptorsRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$importDescriptors, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.ListTransactionsResponse> listTransactions($0.ListTransactionsRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$listTransactions, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetDescriptorInfoResponse> getDescriptorInfo($0.GetDescriptorInfoRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getDescriptorInfo, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetRawMempoolResponse> getRawMempool($0.GetRawMempoolRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getRawMempool, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetRawTransactionResponse> getRawTransaction($0.GetRawTransactionRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getRawTransaction, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.DecodeRawTransactionResponse> decodeRawTransaction($0.DecodeRawTransactionRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$decodeRawTransaction, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetBlockResponse> getBlock($0.GetBlockRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getBlock, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.GetBlockHashResponse> getBlockHash($0.GetBlockHashRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$getBlockHash, request, options: options);
+  }
+}
+
+@$pb.GrpcServiceName('bitcoin.bitcoind.v1alpha.BitcoinService')
+abstract class BitcoinServiceBase extends $grpc.Service {
+  $core.String get $name => 'bitcoin.bitcoind.v1alpha.BitcoinService';
+
+  BitcoinServiceBase() {
+    $addMethod($grpc.ServiceMethod<$0.GetBlockchainInfoRequest, $0.GetBlockchainInfoResponse>(
+        'GetBlockchainInfo',
+        getBlockchainInfo_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetBlockchainInfoRequest.fromBuffer(value),
+        ($0.GetBlockchainInfoResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetTransactionRequest, $0.GetTransactionResponse>(
+        'GetTransaction',
+        getTransaction_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetTransactionRequest.fromBuffer(value),
+        ($0.GetTransactionResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ListSinceBlockRequest, $0.ListSinceBlockResponse>(
+        'ListSinceBlock',
+        listSinceBlock_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.ListSinceBlockRequest.fromBuffer(value),
+        ($0.ListSinceBlockResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetNewAddressRequest, $0.GetNewAddressResponse>(
+        'GetNewAddress',
+        getNewAddress_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetNewAddressRequest.fromBuffer(value),
+        ($0.GetNewAddressResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetWalletInfoRequest, $0.GetWalletInfoResponse>(
+        'GetWalletInfo',
+        getWalletInfo_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetWalletInfoRequest.fromBuffer(value),
+        ($0.GetWalletInfoResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetBalancesRequest, $0.GetBalancesResponse>(
+        'GetBalances',
+        getBalances_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetBalancesRequest.fromBuffer(value),
+        ($0.GetBalancesResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.SendRequest, $0.SendResponse>(
+        'Send',
+        send_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.SendRequest.fromBuffer(value),
+        ($0.SendResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.SendToAddressRequest, $0.SendToAddressResponse>(
+        'SendToAddress',
+        sendToAddress_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.SendToAddressRequest.fromBuffer(value),
+        ($0.SendToAddressResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.BumpFeeRequest, $0.BumpFeeResponse>(
+        'BumpFee',
+        bumpFee_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.BumpFeeRequest.fromBuffer(value),
+        ($0.BumpFeeResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.EstimateSmartFeeRequest, $0.EstimateSmartFeeResponse>(
+        'EstimateSmartFee',
+        estimateSmartFee_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.EstimateSmartFeeRequest.fromBuffer(value),
+        ($0.EstimateSmartFeeResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ImportDescriptorsRequest, $0.ImportDescriptorsResponse>(
+        'ImportDescriptors',
+        importDescriptors_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.ImportDescriptorsRequest.fromBuffer(value),
+        ($0.ImportDescriptorsResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ListTransactionsRequest, $0.ListTransactionsResponse>(
+        'ListTransactions',
+        listTransactions_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.ListTransactionsRequest.fromBuffer(value),
+        ($0.ListTransactionsResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetDescriptorInfoRequest, $0.GetDescriptorInfoResponse>(
+        'GetDescriptorInfo',
+        getDescriptorInfo_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetDescriptorInfoRequest.fromBuffer(value),
+        ($0.GetDescriptorInfoResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetRawMempoolRequest, $0.GetRawMempoolResponse>(
+        'GetRawMempool',
+        getRawMempool_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetRawMempoolRequest.fromBuffer(value),
+        ($0.GetRawMempoolResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetRawTransactionRequest, $0.GetRawTransactionResponse>(
+        'GetRawTransaction',
+        getRawTransaction_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetRawTransactionRequest.fromBuffer(value),
+        ($0.GetRawTransactionResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.DecodeRawTransactionRequest, $0.DecodeRawTransactionResponse>(
+        'DecodeRawTransaction',
+        decodeRawTransaction_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.DecodeRawTransactionRequest.fromBuffer(value),
+        ($0.DecodeRawTransactionResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetBlockRequest, $0.GetBlockResponse>(
+        'GetBlock',
+        getBlock_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetBlockRequest.fromBuffer(value),
+        ($0.GetBlockResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.GetBlockHashRequest, $0.GetBlockHashResponse>(
+        'GetBlockHash',
+        getBlockHash_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.GetBlockHashRequest.fromBuffer(value),
+        ($0.GetBlockHashResponse value) => value.writeToBuffer()));
+  }
+
+  $async.Future<$0.GetBlockchainInfoResponse> getBlockchainInfo_Pre($grpc.ServiceCall call, $async.Future<$0.GetBlockchainInfoRequest> request) async {
+    return getBlockchainInfo(call, await request);
+  }
+
+  $async.Future<$0.GetTransactionResponse> getTransaction_Pre($grpc.ServiceCall call, $async.Future<$0.GetTransactionRequest> request) async {
+    return getTransaction(call, await request);
+  }
+
+  $async.Future<$0.ListSinceBlockResponse> listSinceBlock_Pre($grpc.ServiceCall call, $async.Future<$0.ListSinceBlockRequest> request) async {
+    return listSinceBlock(call, await request);
+  }
+
+  $async.Future<$0.GetNewAddressResponse> getNewAddress_Pre($grpc.ServiceCall call, $async.Future<$0.GetNewAddressRequest> request) async {
+    return getNewAddress(call, await request);
+  }
+
+  $async.Future<$0.GetWalletInfoResponse> getWalletInfo_Pre($grpc.ServiceCall call, $async.Future<$0.GetWalletInfoRequest> request) async {
+    return getWalletInfo(call, await request);
+  }
+
+  $async.Future<$0.GetBalancesResponse> getBalances_Pre($grpc.ServiceCall call, $async.Future<$0.GetBalancesRequest> request) async {
+    return getBalances(call, await request);
+  }
+
+  $async.Future<$0.SendResponse> send_Pre($grpc.ServiceCall call, $async.Future<$0.SendRequest> request) async {
+    return send(call, await request);
+  }
+
+  $async.Future<$0.SendToAddressResponse> sendToAddress_Pre($grpc.ServiceCall call, $async.Future<$0.SendToAddressRequest> request) async {
+    return sendToAddress(call, await request);
+  }
+
+  $async.Future<$0.BumpFeeResponse> bumpFee_Pre($grpc.ServiceCall call, $async.Future<$0.BumpFeeRequest> request) async {
+    return bumpFee(call, await request);
+  }
+
+  $async.Future<$0.EstimateSmartFeeResponse> estimateSmartFee_Pre($grpc.ServiceCall call, $async.Future<$0.EstimateSmartFeeRequest> request) async {
+    return estimateSmartFee(call, await request);
+  }
+
+  $async.Future<$0.ImportDescriptorsResponse> importDescriptors_Pre($grpc.ServiceCall call, $async.Future<$0.ImportDescriptorsRequest> request) async {
+    return importDescriptors(call, await request);
+  }
+
+  $async.Future<$0.ListTransactionsResponse> listTransactions_Pre($grpc.ServiceCall call, $async.Future<$0.ListTransactionsRequest> request) async {
+    return listTransactions(call, await request);
+  }
+
+  $async.Future<$0.GetDescriptorInfoResponse> getDescriptorInfo_Pre($grpc.ServiceCall call, $async.Future<$0.GetDescriptorInfoRequest> request) async {
+    return getDescriptorInfo(call, await request);
+  }
+
+  $async.Future<$0.GetRawMempoolResponse> getRawMempool_Pre($grpc.ServiceCall call, $async.Future<$0.GetRawMempoolRequest> request) async {
+    return getRawMempool(call, await request);
+  }
+
+  $async.Future<$0.GetRawTransactionResponse> getRawTransaction_Pre($grpc.ServiceCall call, $async.Future<$0.GetRawTransactionRequest> request) async {
+    return getRawTransaction(call, await request);
+  }
+
+  $async.Future<$0.DecodeRawTransactionResponse> decodeRawTransaction_Pre($grpc.ServiceCall call, $async.Future<$0.DecodeRawTransactionRequest> request) async {
+    return decodeRawTransaction(call, await request);
+  }
+
+  $async.Future<$0.GetBlockResponse> getBlock_Pre($grpc.ServiceCall call, $async.Future<$0.GetBlockRequest> request) async {
+    return getBlock(call, await request);
+  }
+
+  $async.Future<$0.GetBlockHashResponse> getBlockHash_Pre($grpc.ServiceCall call, $async.Future<$0.GetBlockHashRequest> request) async {
+    return getBlockHash(call, await request);
+  }
+
+  $async.Future<$0.GetBlockchainInfoResponse> getBlockchainInfo($grpc.ServiceCall call, $0.GetBlockchainInfoRequest request);
+  $async.Future<$0.GetTransactionResponse> getTransaction($grpc.ServiceCall call, $0.GetTransactionRequest request);
+  $async.Future<$0.ListSinceBlockResponse> listSinceBlock($grpc.ServiceCall call, $0.ListSinceBlockRequest request);
+  $async.Future<$0.GetNewAddressResponse> getNewAddress($grpc.ServiceCall call, $0.GetNewAddressRequest request);
+  $async.Future<$0.GetWalletInfoResponse> getWalletInfo($grpc.ServiceCall call, $0.GetWalletInfoRequest request);
+  $async.Future<$0.GetBalancesResponse> getBalances($grpc.ServiceCall call, $0.GetBalancesRequest request);
+  $async.Future<$0.SendResponse> send($grpc.ServiceCall call, $0.SendRequest request);
+  $async.Future<$0.SendToAddressResponse> sendToAddress($grpc.ServiceCall call, $0.SendToAddressRequest request);
+  $async.Future<$0.BumpFeeResponse> bumpFee($grpc.ServiceCall call, $0.BumpFeeRequest request);
+  $async.Future<$0.EstimateSmartFeeResponse> estimateSmartFee($grpc.ServiceCall call, $0.EstimateSmartFeeRequest request);
+  $async.Future<$0.ImportDescriptorsResponse> importDescriptors($grpc.ServiceCall call, $0.ImportDescriptorsRequest request);
+  $async.Future<$0.ListTransactionsResponse> listTransactions($grpc.ServiceCall call, $0.ListTransactionsRequest request);
+  $async.Future<$0.GetDescriptorInfoResponse> getDescriptorInfo($grpc.ServiceCall call, $0.GetDescriptorInfoRequest request);
+  $async.Future<$0.GetRawMempoolResponse> getRawMempool($grpc.ServiceCall call, $0.GetRawMempoolRequest request);
+  $async.Future<$0.GetRawTransactionResponse> getRawTransaction($grpc.ServiceCall call, $0.GetRawTransactionRequest request);
+  $async.Future<$0.DecodeRawTransactionResponse> decodeRawTransaction($grpc.ServiceCall call, $0.DecodeRawTransactionRequest request);
+  $async.Future<$0.GetBlockResponse> getBlock($grpc.ServiceCall call, $0.GetBlockRequest request);
+  $async.Future<$0.GetBlockHashResponse> getBlockHash($grpc.ServiceCall call, $0.GetBlockHashRequest request);
+}

--- a/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbjson.dart
+++ b/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbjson.dart
@@ -1,0 +1,1034 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/bitcoind/v1alpha/bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+import '../../../google/protobuf/timestamp.pbjson.dart' as $0;
+import '../../../google/protobuf/wrappers.pbjson.dart' as $1;
+
+@$core.Deprecated('Use getBlockchainInfoRequestDescriptor instead')
+const GetBlockchainInfoRequest$json = {
+  '1': 'GetBlockchainInfoRequest',
+};
+
+/// Descriptor for `GetBlockchainInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBlockchainInfoRequestDescriptor = $convert.base64Decode(
+    'ChhHZXRCbG9ja2NoYWluSW5mb1JlcXVlc3Q=');
+
+@$core.Deprecated('Use getBlockchainInfoResponseDescriptor instead')
+const GetBlockchainInfoResponse$json = {
+  '1': 'GetBlockchainInfoResponse',
+  '2': [
+    {'1': 'best_block_hash', '3': 1, '4': 1, '5': 9, '10': 'bestBlockHash'},
+    {'1': 'blocks', '3': 5, '4': 1, '5': 13, '10': 'blocks'},
+    {'1': 'headers', '3': 6, '4': 1, '5': 13, '10': 'headers'},
+    {'1': 'chain', '3': 2, '4': 1, '5': 9, '10': 'chain'},
+    {'1': 'chain_work', '3': 3, '4': 1, '5': 9, '10': 'chainWork'},
+    {'1': 'initial_block_download', '3': 4, '4': 1, '5': 8, '10': 'initialBlockDownload'},
+  ],
+};
+
+/// Descriptor for `GetBlockchainInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBlockchainInfoResponseDescriptor = $convert.base64Decode(
+    'ChlHZXRCbG9ja2NoYWluSW5mb1Jlc3BvbnNlEiYKD2Jlc3RfYmxvY2tfaGFzaBgBIAEoCVINYm'
+    'VzdEJsb2NrSGFzaBIWCgZibG9ja3MYBSABKA1SBmJsb2NrcxIYCgdoZWFkZXJzGAYgASgNUgdo'
+    'ZWFkZXJzEhQKBWNoYWluGAIgASgJUgVjaGFpbhIdCgpjaGFpbl93b3JrGAMgASgJUgljaGFpbl'
+    'dvcmsSNAoWaW5pdGlhbF9ibG9ja19kb3dubG9hZBgEIAEoCFIUaW5pdGlhbEJsb2NrRG93bmxv'
+    'YWQ=');
+
+@$core.Deprecated('Use getNewAddressRequestDescriptor instead')
+const GetNewAddressRequest$json = {
+  '1': 'GetNewAddressRequest',
+  '2': [
+    {'1': 'label', '3': 1, '4': 1, '5': 9, '10': 'label'},
+    {'1': 'address_type', '3': 2, '4': 1, '5': 9, '10': 'addressType'},
+    {'1': 'wallet', '3': 3, '4': 1, '5': 9, '10': 'wallet'},
+  ],
+};
+
+/// Descriptor for `GetNewAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getNewAddressRequestDescriptor = $convert.base64Decode(
+    'ChRHZXROZXdBZGRyZXNzUmVxdWVzdBIUCgVsYWJlbBgBIAEoCVIFbGFiZWwSIQoMYWRkcmVzc1'
+    '90eXBlGAIgASgJUgthZGRyZXNzVHlwZRIWCgZ3YWxsZXQYAyABKAlSBndhbGxldA==');
+
+@$core.Deprecated('Use getNewAddressResponseDescriptor instead')
+const GetNewAddressResponse$json = {
+  '1': 'GetNewAddressResponse',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `GetNewAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getNewAddressResponseDescriptor = $convert.base64Decode(
+    'ChVHZXROZXdBZGRyZXNzUmVzcG9uc2USGAoHYWRkcmVzcxgBIAEoCVIHYWRkcmVzcw==');
+
+@$core.Deprecated('Use getWalletInfoRequestDescriptor instead')
+const GetWalletInfoRequest$json = {
+  '1': 'GetWalletInfoRequest',
+  '2': [
+    {'1': 'wallet', '3': 1, '4': 1, '5': 9, '10': 'wallet'},
+  ],
+};
+
+/// Descriptor for `GetWalletInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getWalletInfoRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRXYWxsZXRJbmZvUmVxdWVzdBIWCgZ3YWxsZXQYASABKAlSBndhbGxldA==');
+
+@$core.Deprecated('Use getWalletInfoResponseDescriptor instead')
+const GetWalletInfoResponse$json = {
+  '1': 'GetWalletInfoResponse',
+  '2': [
+    {'1': 'wallet_name', '3': 1, '4': 1, '5': 9, '10': 'walletName'},
+    {'1': 'wallet_version', '3': 2, '4': 1, '5': 3, '10': 'walletVersion'},
+    {'1': 'format', '3': 3, '4': 1, '5': 9, '10': 'format'},
+    {'1': 'tx_count', '3': 7, '4': 1, '5': 3, '10': 'txCount'},
+    {'1': 'key_pool_size', '3': 8, '4': 1, '5': 3, '10': 'keyPoolSize'},
+    {'1': 'key_pool_size_hd_internal', '3': 9, '4': 1, '5': 3, '10': 'keyPoolSizeHdInternal'},
+    {'1': 'pay_tx_fee', '3': 10, '4': 1, '5': 1, '10': 'payTxFee'},
+    {'1': 'private_keys_enabled', '3': 11, '4': 1, '5': 8, '10': 'privateKeysEnabled'},
+    {'1': 'avoid_reuse', '3': 12, '4': 1, '5': 8, '10': 'avoidReuse'},
+    {'1': 'scanning', '3': 13, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.WalletScan', '10': 'scanning'},
+    {'1': 'descriptors', '3': 14, '4': 1, '5': 8, '10': 'descriptors'},
+    {'1': 'external_signer', '3': 15, '4': 1, '5': 8, '10': 'externalSigner'},
+  ],
+};
+
+/// Descriptor for `GetWalletInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getWalletInfoResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRXYWxsZXRJbmZvUmVzcG9uc2USHwoLd2FsbGV0X25hbWUYASABKAlSCndhbGxldE5hbW'
+    'USJQoOd2FsbGV0X3ZlcnNpb24YAiABKANSDXdhbGxldFZlcnNpb24SFgoGZm9ybWF0GAMgASgJ'
+    'UgZmb3JtYXQSGQoIdHhfY291bnQYByABKANSB3R4Q291bnQSIgoNa2V5X3Bvb2xfc2l6ZRgIIA'
+    'EoA1ILa2V5UG9vbFNpemUSOAoZa2V5X3Bvb2xfc2l6ZV9oZF9pbnRlcm5hbBgJIAEoA1IVa2V5'
+    'UG9vbFNpemVIZEludGVybmFsEhwKCnBheV90eF9mZWUYCiABKAFSCHBheVR4RmVlEjAKFHByaX'
+    'ZhdGVfa2V5c19lbmFibGVkGAsgASgIUhJwcml2YXRlS2V5c0VuYWJsZWQSHwoLYXZvaWRfcmV1'
+    'c2UYDCABKAhSCmF2b2lkUmV1c2USQAoIc2Nhbm5pbmcYDSABKAsyJC5iaXRjb2luLmJpdGNvaW'
+    '5kLnYxYWxwaGEuV2FsbGV0U2NhblIIc2Nhbm5pbmcSIAoLZGVzY3JpcHRvcnMYDiABKAhSC2Rl'
+    'c2NyaXB0b3JzEicKD2V4dGVybmFsX3NpZ25lchgPIAEoCFIOZXh0ZXJuYWxTaWduZXI=');
+
+@$core.Deprecated('Use getBalancesRequestDescriptor instead')
+const GetBalancesRequest$json = {
+  '1': 'GetBalancesRequest',
+  '2': [
+    {'1': 'wallet', '3': 1, '4': 1, '5': 9, '10': 'wallet'},
+  ],
+};
+
+/// Descriptor for `GetBalancesRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBalancesRequestDescriptor = $convert.base64Decode(
+    'ChJHZXRCYWxhbmNlc1JlcXVlc3QSFgoGd2FsbGV0GAEgASgJUgZ3YWxsZXQ=');
+
+@$core.Deprecated('Use getBalancesResponseDescriptor instead')
+const GetBalancesResponse$json = {
+  '1': 'GetBalancesResponse',
+  '2': [
+    {'1': 'mine', '3': 1, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.GetBalancesResponse.Mine', '10': 'mine'},
+    {'1': 'watchonly', '3': 2, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.GetBalancesResponse.Watchonly', '10': 'watchonly'},
+  ],
+  '3': [GetBalancesResponse_Mine$json, GetBalancesResponse_Watchonly$json],
+};
+
+@$core.Deprecated('Use getBalancesResponseDescriptor instead')
+const GetBalancesResponse_Mine$json = {
+  '1': 'Mine',
+  '2': [
+    {'1': 'trusted', '3': 1, '4': 1, '5': 1, '10': 'trusted'},
+    {'1': 'untrusted_pending', '3': 2, '4': 1, '5': 1, '10': 'untrustedPending'},
+    {'1': 'immature', '3': 3, '4': 1, '5': 1, '10': 'immature'},
+    {'1': 'used', '3': 4, '4': 1, '5': 1, '10': 'used'},
+  ],
+};
+
+@$core.Deprecated('Use getBalancesResponseDescriptor instead')
+const GetBalancesResponse_Watchonly$json = {
+  '1': 'Watchonly',
+  '2': [
+    {'1': 'trusted', '3': 1, '4': 1, '5': 1, '10': 'trusted'},
+    {'1': 'untrusted_pending', '3': 2, '4': 1, '5': 1, '10': 'untrustedPending'},
+    {'1': 'immature', '3': 3, '4': 1, '5': 1, '10': 'immature'},
+  ],
+};
+
+/// Descriptor for `GetBalancesResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBalancesResponseDescriptor = $convert.base64Decode(
+    'ChNHZXRCYWxhbmNlc1Jlc3BvbnNlEkYKBG1pbmUYASABKAsyMi5iaXRjb2luLmJpdGNvaW5kLn'
+    'YxYWxwaGEuR2V0QmFsYW5jZXNSZXNwb25zZS5NaW5lUgRtaW5lElUKCXdhdGNob25seRgCIAEo'
+    'CzI3LmJpdGNvaW4uYml0Y29pbmQudjFhbHBoYS5HZXRCYWxhbmNlc1Jlc3BvbnNlLldhdGNob2'
+    '5seVIJd2F0Y2hvbmx5Gn0KBE1pbmUSGAoHdHJ1c3RlZBgBIAEoAVIHdHJ1c3RlZBIrChF1bnRy'
+    'dXN0ZWRfcGVuZGluZxgCIAEoAVIQdW50cnVzdGVkUGVuZGluZxIaCghpbW1hdHVyZRgDIAEoAV'
+    'IIaW1tYXR1cmUSEgoEdXNlZBgEIAEoAVIEdXNlZBpuCglXYXRjaG9ubHkSGAoHdHJ1c3RlZBgB'
+    'IAEoAVIHdHJ1c3RlZBIrChF1bnRydXN0ZWRfcGVuZGluZxgCIAEoAVIQdW50cnVzdGVkUGVuZG'
+    'luZxIaCghpbW1hdHVyZRgDIAEoAVIIaW1tYXR1cmU=');
+
+@$core.Deprecated('Use walletScanDescriptor instead')
+const WalletScan$json = {
+  '1': 'WalletScan',
+  '2': [
+    {'1': 'duration', '3': 1, '4': 1, '5': 3, '10': 'duration'},
+    {'1': 'progress', '3': 2, '4': 1, '5': 1, '10': 'progress'},
+  ],
+};
+
+/// Descriptor for `WalletScan`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List walletScanDescriptor = $convert.base64Decode(
+    'CgpXYWxsZXRTY2FuEhoKCGR1cmF0aW9uGAEgASgDUghkdXJhdGlvbhIaCghwcm9ncmVzcxgCIA'
+    'EoAVIIcHJvZ3Jlc3M=');
+
+@$core.Deprecated('Use getTransactionRequestDescriptor instead')
+const GetTransactionRequest$json = {
+  '1': 'GetTransactionRequest',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'include_watchonly', '3': 2, '4': 1, '5': 8, '10': 'includeWatchonly'},
+    {'1': 'verbose', '3': 3, '4': 1, '5': 8, '10': 'verbose'},
+    {'1': 'wallet', '3': 4, '4': 1, '5': 9, '10': 'wallet'},
+  ],
+};
+
+/// Descriptor for `GetTransactionRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getTransactionRequestDescriptor = $convert.base64Decode(
+    'ChVHZXRUcmFuc2FjdGlvblJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZBIrChFpbmNsdWRlX3'
+    'dhdGNob25seRgCIAEoCFIQaW5jbHVkZVdhdGNob25seRIYCgd2ZXJib3NlGAMgASgIUgd2ZXJi'
+    'b3NlEhYKBndhbGxldBgEIAEoCVIGd2FsbGV0');
+
+@$core.Deprecated('Use getTransactionResponseDescriptor instead')
+const GetTransactionResponse$json = {
+  '1': 'GetTransactionResponse',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 1, '5': 1, '10': 'amount'},
+    {'1': 'fee', '3': 2, '4': 1, '5': 1, '10': 'fee'},
+    {'1': 'confirmations', '3': 3, '4': 1, '5': 5, '10': 'confirmations'},
+    {'1': 'block_hash', '3': 6, '4': 1, '5': 9, '10': 'blockHash'},
+    {'1': 'block_index', '3': 8, '4': 1, '5': 13, '10': 'blockIndex'},
+    {'1': 'block_time', '3': 9, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'blockTime'},
+    {'1': 'txid', '3': 10, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'wallet_conflicts', '3': 12, '4': 3, '5': 9, '10': 'walletConflicts'},
+    {'1': 'replaced_by_txid', '3': 13, '4': 1, '5': 9, '10': 'replacedByTxid'},
+    {'1': 'replaces_txid', '3': 14, '4': 1, '5': 9, '10': 'replacesTxid'},
+    {'1': 'time', '3': 17, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'time'},
+    {'1': 'time_received', '3': 18, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'timeReceived'},
+    {'1': 'bip125_replaceable', '3': 19, '4': 1, '5': 14, '6': '.bitcoin.bitcoind.v1alpha.GetTransactionResponse.Replaceable', '10': 'bip125Replaceable'},
+    {'1': 'details', '3': 21, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.GetTransactionResponse.Details', '10': 'details'},
+    {'1': 'hex', '3': 22, '4': 1, '5': 9, '10': 'hex'},
+  ],
+  '3': [GetTransactionResponse_Details$json],
+  '4': [GetTransactionResponse_Replaceable$json, GetTransactionResponse_Category$json],
+};
+
+@$core.Deprecated('Use getTransactionResponseDescriptor instead')
+const GetTransactionResponse_Details$json = {
+  '1': 'Details',
+  '2': [
+    {'1': 'involves_watch_only', '3': 1, '4': 1, '5': 8, '10': 'involvesWatchOnly'},
+    {'1': 'address', '3': 2, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'category', '3': 3, '4': 1, '5': 14, '6': '.bitcoin.bitcoind.v1alpha.GetTransactionResponse.Category', '10': 'category'},
+    {'1': 'amount', '3': 4, '4': 1, '5': 1, '10': 'amount'},
+    {'1': 'vout', '3': 6, '4': 1, '5': 13, '10': 'vout'},
+    {'1': 'fee', '3': 7, '4': 1, '5': 1, '10': 'fee'},
+  ],
+};
+
+@$core.Deprecated('Use getTransactionResponseDescriptor instead')
+const GetTransactionResponse_Replaceable$json = {
+  '1': 'Replaceable',
+  '2': [
+    {'1': 'REPLACEABLE_UNSPECIFIED', '2': 0},
+    {'1': 'REPLACEABLE_YES', '2': 1},
+    {'1': 'REPLACEABLE_NO', '2': 2},
+  ],
+};
+
+@$core.Deprecated('Use getTransactionResponseDescriptor instead')
+const GetTransactionResponse_Category$json = {
+  '1': 'Category',
+  '2': [
+    {'1': 'CATEGORY_UNSPECIFIED', '2': 0},
+    {'1': 'CATEGORY_SEND', '2': 1},
+    {'1': 'CATEGORY_RECEIVE', '2': 2},
+    {'1': 'CATEGORY_GENERATE', '2': 3},
+    {'1': 'CATEGORY_IMMATURE', '2': 4},
+    {'1': 'CATEGORY_ORPHAN', '2': 5},
+  ],
+};
+
+/// Descriptor for `GetTransactionResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getTransactionResponseDescriptor = $convert.base64Decode(
+    'ChZHZXRUcmFuc2FjdGlvblJlc3BvbnNlEhYKBmFtb3VudBgBIAEoAVIGYW1vdW50EhAKA2ZlZR'
+    'gCIAEoAVIDZmVlEiQKDWNvbmZpcm1hdGlvbnMYAyABKAVSDWNvbmZpcm1hdGlvbnMSHQoKYmxv'
+    'Y2tfaGFzaBgGIAEoCVIJYmxvY2tIYXNoEh8KC2Jsb2NrX2luZGV4GAggASgNUgpibG9ja0luZG'
+    'V4EjkKCmJsb2NrX3RpbWUYCSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUglibG9j'
+    'a1RpbWUSEgoEdHhpZBgKIAEoCVIEdHhpZBIpChB3YWxsZXRfY29uZmxpY3RzGAwgAygJUg93YW'
+    'xsZXRDb25mbGljdHMSKAoQcmVwbGFjZWRfYnlfdHhpZBgNIAEoCVIOcmVwbGFjZWRCeVR4aWQS'
+    'IwoNcmVwbGFjZXNfdHhpZBgOIAEoCVIMcmVwbGFjZXNUeGlkEi4KBHRpbWUYESABKAsyGi5nb2'
+    '9nbGUucHJvdG9idWYuVGltZXN0YW1wUgR0aW1lEj8KDXRpbWVfcmVjZWl2ZWQYEiABKAsyGi5n'
+    'b29nbGUucHJvdG9idWYuVGltZXN0YW1wUgx0aW1lUmVjZWl2ZWQSawoSYmlwMTI1X3JlcGxhY2'
+    'VhYmxlGBMgASgOMjwuYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldFRyYW5zYWN0aW9uUmVz'
+    'cG9uc2UuUmVwbGFjZWFibGVSEWJpcDEyNVJlcGxhY2VhYmxlElIKB2RldGFpbHMYFSADKAsyOC'
+    '5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuR2V0VHJhbnNhY3Rpb25SZXNwb25zZS5EZXRhaWxz'
+    'UgdkZXRhaWxzEhAKA2hleBgWIAEoCVIDaGV4GugBCgdEZXRhaWxzEi4KE2ludm9sdmVzX3dhdG'
+    'NoX29ubHkYASABKAhSEWludm9sdmVzV2F0Y2hPbmx5EhgKB2FkZHJlc3MYAiABKAlSB2FkZHJl'
+    'c3MSVQoIY2F0ZWdvcnkYAyABKA4yOS5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuR2V0VHJhbn'
+    'NhY3Rpb25SZXNwb25zZS5DYXRlZ29yeVIIY2F0ZWdvcnkSFgoGYW1vdW50GAQgASgBUgZhbW91'
+    'bnQSEgoEdm91dBgGIAEoDVIEdm91dBIQCgNmZWUYByABKAFSA2ZlZSJTCgtSZXBsYWNlYWJsZR'
+    'IbChdSRVBMQUNFQUJMRV9VTlNQRUNJRklFRBAAEhMKD1JFUExBQ0VBQkxFX1lFUxABEhIKDlJF'
+    'UExBQ0VBQkxFX05PEAIikAEKCENhdGVnb3J5EhgKFENBVEVHT1JZX1VOU1BFQ0lGSUVEEAASEQ'
+    'oNQ0FURUdPUllfU0VORBABEhQKEENBVEVHT1JZX1JFQ0VJVkUQAhIVChFDQVRFR09SWV9HRU5F'
+    'UkFURRADEhUKEUNBVEVHT1JZX0lNTUFUVVJFEAQSEwoPQ0FURUdPUllfT1JQSEFOEAU=');
+
+@$core.Deprecated('Use getRawTransactionRequestDescriptor instead')
+const GetRawTransactionRequest$json = {
+  '1': 'GetRawTransactionRequest',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'verbose', '3': 2, '4': 1, '5': 8, '10': 'verbose'},
+  ],
+};
+
+/// Descriptor for `GetRawTransactionRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getRawTransactionRequestDescriptor = $convert.base64Decode(
+    'ChhHZXRSYXdUcmFuc2FjdGlvblJlcXVlc3QSEgoEdHhpZBgBIAEoCVIEdHhpZBIYCgd2ZXJib3'
+    'NlGAIgASgIUgd2ZXJib3Nl');
+
+@$core.Deprecated('Use inputDescriptor instead')
+const Input$json = {
+  '1': 'Input',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'vout', '3': 2, '4': 1, '5': 13, '10': 'vout'},
+  ],
+};
+
+/// Descriptor for `Input`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List inputDescriptor = $convert.base64Decode(
+    'CgVJbnB1dBISCgR0eGlkGAEgASgJUgR0eGlkEhIKBHZvdXQYAiABKA1SBHZvdXQ=');
+
+@$core.Deprecated('Use scriptPubKeyDescriptor instead')
+const ScriptPubKey$json = {
+  '1': 'ScriptPubKey',
+  '2': [
+    {'1': 'type', '3': 1, '4': 1, '5': 9, '10': 'type'},
+    {'1': 'address', '3': 2, '4': 1, '5': 9, '10': 'address'},
+  ],
+};
+
+/// Descriptor for `ScriptPubKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List scriptPubKeyDescriptor = $convert.base64Decode(
+    'CgxTY3JpcHRQdWJLZXkSEgoEdHlwZRgBIAEoCVIEdHlwZRIYCgdhZGRyZXNzGAIgASgJUgdhZG'
+    'RyZXNz');
+
+@$core.Deprecated('Use outputDescriptor instead')
+const Output$json = {
+  '1': 'Output',
+  '2': [
+    {'1': 'amount', '3': 1, '4': 1, '5': 1, '10': 'amount'},
+    {'1': 'n', '3': 2, '4': 1, '5': 13, '10': 'n'},
+    {'1': 'script_pub_key', '3': 3, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.ScriptPubKey', '10': 'scriptPubKey'},
+  ],
+};
+
+/// Descriptor for `Output`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List outputDescriptor = $convert.base64Decode(
+    'CgZPdXRwdXQSFgoGYW1vdW50GAEgASgBUgZhbW91bnQSDAoBbhgCIAEoDVIBbhJMCg5zY3JpcH'
+    'RfcHViX2tleRgDIAEoCzImLmJpdGNvaW4uYml0Y29pbmQudjFhbHBoYS5TY3JpcHRQdWJLZXlS'
+    'DHNjcmlwdFB1YktleQ==');
+
+@$core.Deprecated('Use getRawTransactionResponseDescriptor instead')
+const GetRawTransactionResponse$json = {
+  '1': 'GetRawTransactionResponse',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.RawTransaction', '10': 'tx'},
+    {'1': 'inputs', '3': 2, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.Input', '10': 'inputs'},
+    {'1': 'outputs', '3': 3, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.Output', '10': 'outputs'},
+    {'1': 'blockhash', '3': 4, '4': 1, '5': 9, '10': 'blockhash'},
+    {'1': 'confirmations', '3': 5, '4': 1, '5': 13, '10': 'confirmations'},
+    {'1': 'time', '3': 6, '4': 1, '5': 3, '10': 'time'},
+    {'1': 'blocktime', '3': 7, '4': 1, '5': 3, '10': 'blocktime'},
+  ],
+};
+
+/// Descriptor for `GetRawTransactionResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getRawTransactionResponseDescriptor = $convert.base64Decode(
+    'ChlHZXRSYXdUcmFuc2FjdGlvblJlc3BvbnNlEjgKAnR4GAEgASgLMiguYml0Y29pbi5iaXRjb2'
+    'luZC52MWFscGhhLlJhd1RyYW5zYWN0aW9uUgJ0eBI3CgZpbnB1dHMYAiADKAsyHy5iaXRjb2lu'
+    'LmJpdGNvaW5kLnYxYWxwaGEuSW5wdXRSBmlucHV0cxI6CgdvdXRwdXRzGAMgAygLMiAuYml0Y2'
+    '9pbi5iaXRjb2luZC52MWFscGhhLk91dHB1dFIHb3V0cHV0cxIcCglibG9ja2hhc2gYBCABKAlS'
+    'CWJsb2NraGFzaBIkCg1jb25maXJtYXRpb25zGAUgASgNUg1jb25maXJtYXRpb25zEhIKBHRpbW'
+    'UYBiABKANSBHRpbWUSHAoJYmxvY2t0aW1lGAcgASgDUglibG9ja3RpbWU=');
+
+@$core.Deprecated('Use sendRequestDescriptor instead')
+const SendRequest$json = {
+  '1': 'SendRequest',
+  '2': [
+    {'1': 'destinations', '3': 1, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.SendRequest.DestinationsEntry', '10': 'destinations'},
+    {'1': 'conf_target', '3': 2, '4': 1, '5': 13, '10': 'confTarget'},
+    {'1': 'wallet', '3': 3, '4': 1, '5': 9, '10': 'wallet'},
+    {'1': 'include_unsafe', '3': 4, '4': 1, '5': 8, '10': 'includeUnsafe'},
+    {'1': 'subtract_fee_from_outputs', '3': 5, '4': 3, '5': 9, '10': 'subtractFeeFromOutputs'},
+    {'1': 'add_to_wallet', '3': 6, '4': 1, '5': 11, '6': '.google.protobuf.BoolValue', '10': 'addToWallet'},
+    {'1': 'fee_rate', '3': 7, '4': 1, '5': 1, '10': 'feeRate'},
+  ],
+  '3': [SendRequest_DestinationsEntry$json],
+};
+
+@$core.Deprecated('Use sendRequestDescriptor instead')
+const SendRequest_DestinationsEntry$json = {
+  '1': 'DestinationsEntry',
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 1, '10': 'value'},
+  ],
+  '7': {'7': true},
+};
+
+/// Descriptor for `SendRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sendRequestDescriptor = $convert.base64Decode(
+    'CgtTZW5kUmVxdWVzdBJbCgxkZXN0aW5hdGlvbnMYASADKAsyNy5iaXRjb2luLmJpdGNvaW5kLn'
+    'YxYWxwaGEuU2VuZFJlcXVlc3QuRGVzdGluYXRpb25zRW50cnlSDGRlc3RpbmF0aW9ucxIfCgtj'
+    'b25mX3RhcmdldBgCIAEoDVIKY29uZlRhcmdldBIWCgZ3YWxsZXQYAyABKAlSBndhbGxldBIlCg'
+    '5pbmNsdWRlX3Vuc2FmZRgEIAEoCFINaW5jbHVkZVVuc2FmZRI5ChlzdWJ0cmFjdF9mZWVfZnJv'
+    'bV9vdXRwdXRzGAUgAygJUhZzdWJ0cmFjdEZlZUZyb21PdXRwdXRzEj4KDWFkZF90b193YWxsZX'
+    'QYBiABKAsyGi5nb29nbGUucHJvdG9idWYuQm9vbFZhbHVlUgthZGRUb1dhbGxldBIZCghmZWVf'
+    'cmF0ZRgHIAEoAVIHZmVlUmF0ZRo/ChFEZXN0aW5hdGlvbnNFbnRyeRIQCgNrZXkYASABKAlSA2'
+    'tleRIUCgV2YWx1ZRgCIAEoAVIFdmFsdWU6AjgB');
+
+@$core.Deprecated('Use sendResponseDescriptor instead')
+const SendResponse$json = {
+  '1': 'SendResponse',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'complete', '3': 2, '4': 1, '5': 8, '10': 'complete'},
+    {'1': 'tx', '3': 3, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.RawTransaction', '10': 'tx'},
+  ],
+};
+
+/// Descriptor for `SendResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sendResponseDescriptor = $convert.base64Decode(
+    'CgxTZW5kUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZBIaCghjb21wbGV0ZRgCIAEoCFIIY2'
+    '9tcGxldGUSOAoCdHgYAyABKAsyKC5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuUmF3VHJhbnNh'
+    'Y3Rpb25SAnR4');
+
+@$core.Deprecated('Use sendToAddressRequestDescriptor instead')
+const SendToAddressRequest$json = {
+  '1': 'SendToAddressRequest',
+  '2': [
+    {'1': 'address', '3': 1, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'amount', '3': 2, '4': 1, '5': 1, '10': 'amount'},
+    {'1': 'comment', '3': 3, '4': 1, '5': 9, '10': 'comment'},
+    {'1': 'comment_to', '3': 4, '4': 1, '5': 9, '10': 'commentTo'},
+    {'1': 'wallet', '3': 5, '4': 1, '5': 9, '10': 'wallet'},
+  ],
+};
+
+/// Descriptor for `SendToAddressRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sendToAddressRequestDescriptor = $convert.base64Decode(
+    'ChRTZW5kVG9BZGRyZXNzUmVxdWVzdBIYCgdhZGRyZXNzGAEgASgJUgdhZGRyZXNzEhYKBmFtb3'
+    'VudBgCIAEoAVIGYW1vdW50EhgKB2NvbW1lbnQYAyABKAlSB2NvbW1lbnQSHQoKY29tbWVudF90'
+    'bxgEIAEoCVIJY29tbWVudFRvEhYKBndhbGxldBgFIAEoCVIGd2FsbGV0');
+
+@$core.Deprecated('Use sendToAddressResponseDescriptor instead')
+const SendToAddressResponse$json = {
+  '1': 'SendToAddressResponse',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+  ],
+};
+
+/// Descriptor for `SendToAddressResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sendToAddressResponseDescriptor = $convert.base64Decode(
+    'ChVTZW5kVG9BZGRyZXNzUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZA==');
+
+@$core.Deprecated('Use estimateSmartFeeRequestDescriptor instead')
+const EstimateSmartFeeRequest$json = {
+  '1': 'EstimateSmartFeeRequest',
+  '2': [
+    {'1': 'conf_target', '3': 1, '4': 1, '5': 3, '10': 'confTarget'},
+    {'1': 'estimate_mode', '3': 2, '4': 1, '5': 14, '6': '.bitcoin.bitcoind.v1alpha.EstimateSmartFeeRequest.EstimateMode', '10': 'estimateMode'},
+  ],
+  '4': [EstimateSmartFeeRequest_EstimateMode$json],
+};
+
+@$core.Deprecated('Use estimateSmartFeeRequestDescriptor instead')
+const EstimateSmartFeeRequest_EstimateMode$json = {
+  '1': 'EstimateMode',
+  '2': [
+    {'1': 'ESTIMATE_MODE_UNSPECIFIED', '2': 0},
+    {'1': 'ESTIMATE_MODE_ECONOMICAL', '2': 1},
+    {'1': 'ESTIMATE_MODE_CONSERVATIVE', '2': 2},
+  ],
+};
+
+/// Descriptor for `EstimateSmartFeeRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List estimateSmartFeeRequestDescriptor = $convert.base64Decode(
+    'ChdFc3RpbWF0ZVNtYXJ0RmVlUmVxdWVzdBIfCgtjb25mX3RhcmdldBgBIAEoA1IKY29uZlRhcm'
+    'dldBJjCg1lc3RpbWF0ZV9tb2RlGAIgASgOMj4uYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkVz'
+    'dGltYXRlU21hcnRGZWVSZXF1ZXN0LkVzdGltYXRlTW9kZVIMZXN0aW1hdGVNb2RlImsKDEVzdG'
+    'ltYXRlTW9kZRIdChlFU1RJTUFURV9NT0RFX1VOU1BFQ0lGSUVEEAASHAoYRVNUSU1BVEVfTU9E'
+    'RV9FQ09OT01JQ0FMEAESHgoaRVNUSU1BVEVfTU9ERV9DT05TRVJWQVRJVkUQAg==');
+
+@$core.Deprecated('Use estimateSmartFeeResponseDescriptor instead')
+const EstimateSmartFeeResponse$json = {
+  '1': 'EstimateSmartFeeResponse',
+  '2': [
+    {'1': 'fee_rate', '3': 1, '4': 1, '5': 1, '10': 'feeRate'},
+    {'1': 'errors', '3': 2, '4': 3, '5': 9, '10': 'errors'},
+    {'1': 'blocks', '3': 3, '4': 1, '5': 3, '10': 'blocks'},
+  ],
+};
+
+/// Descriptor for `EstimateSmartFeeResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List estimateSmartFeeResponseDescriptor = $convert.base64Decode(
+    'ChhFc3RpbWF0ZVNtYXJ0RmVlUmVzcG9uc2USGQoIZmVlX3JhdGUYASABKAFSB2ZlZVJhdGUSFg'
+    'oGZXJyb3JzGAIgAygJUgZlcnJvcnMSFgoGYmxvY2tzGAMgASgDUgZibG9ja3M=');
+
+@$core.Deprecated('Use decodeRawTransactionRequestDescriptor instead')
+const DecodeRawTransactionRequest$json = {
+  '1': 'DecodeRawTransactionRequest',
+  '2': [
+    {'1': 'tx', '3': 1, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.RawTransaction', '10': 'tx'},
+  ],
+};
+
+/// Descriptor for `DecodeRawTransactionRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List decodeRawTransactionRequestDescriptor = $convert.base64Decode(
+    'ChtEZWNvZGVSYXdUcmFuc2FjdGlvblJlcXVlc3QSOAoCdHgYASABKAsyKC5iaXRjb2luLmJpdG'
+    'NvaW5kLnYxYWxwaGEuUmF3VHJhbnNhY3Rpb25SAnR4');
+
+@$core.Deprecated('Use rawTransactionDescriptor instead')
+const RawTransaction$json = {
+  '1': 'RawTransaction',
+  '2': [
+    {'1': 'data', '3': 1, '4': 1, '5': 12, '10': 'data'},
+    {'1': 'hex', '3': 2, '4': 1, '5': 9, '10': 'hex'},
+  ],
+};
+
+/// Descriptor for `RawTransaction`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List rawTransactionDescriptor = $convert.base64Decode(
+    'Cg5SYXdUcmFuc2FjdGlvbhISCgRkYXRhGAEgASgMUgRkYXRhEhAKA2hleBgCIAEoCVIDaGV4');
+
+@$core.Deprecated('Use decodeRawTransactionResponseDescriptor instead')
+const DecodeRawTransactionResponse$json = {
+  '1': 'DecodeRawTransactionResponse',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'hash', '3': 2, '4': 1, '5': 9, '10': 'hash'},
+    {'1': 'size', '3': 3, '4': 1, '5': 13, '10': 'size'},
+    {'1': 'virtual_size', '3': 4, '4': 1, '5': 13, '10': 'virtualSize'},
+    {'1': 'weight', '3': 5, '4': 1, '5': 13, '10': 'weight'},
+    {'1': 'version', '3': 6, '4': 1, '5': 13, '10': 'version'},
+    {'1': 'locktime', '3': 7, '4': 1, '5': 13, '10': 'locktime'},
+    {'1': 'inputs', '3': 8, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.Input', '10': 'inputs'},
+    {'1': 'outputs', '3': 9, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.Output', '10': 'outputs'},
+  ],
+};
+
+/// Descriptor for `DecodeRawTransactionResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List decodeRawTransactionResponseDescriptor = $convert.base64Decode(
+    'ChxEZWNvZGVSYXdUcmFuc2FjdGlvblJlc3BvbnNlEhIKBHR4aWQYASABKAlSBHR4aWQSEgoEaG'
+    'FzaBgCIAEoCVIEaGFzaBISCgRzaXplGAMgASgNUgRzaXplEiEKDHZpcnR1YWxfc2l6ZRgEIAEo'
+    'DVILdmlydHVhbFNpemUSFgoGd2VpZ2h0GAUgASgNUgZ3ZWlnaHQSGAoHdmVyc2lvbhgGIAEoDV'
+    'IHdmVyc2lvbhIaCghsb2NrdGltZRgHIAEoDVIIbG9ja3RpbWUSNwoGaW5wdXRzGAggAygLMh8u'
+    'Yml0Y29pbi5iaXRjb2luZC52MWFscGhhLklucHV0UgZpbnB1dHMSOgoHb3V0cHV0cxgJIAMoCz'
+    'IgLmJpdGNvaW4uYml0Y29pbmQudjFhbHBoYS5PdXRwdXRSB291dHB1dHM=');
+
+@$core.Deprecated('Use importDescriptorsRequestDescriptor instead')
+const ImportDescriptorsRequest$json = {
+  '1': 'ImportDescriptorsRequest',
+  '2': [
+    {'1': 'wallet', '3': 1, '4': 1, '5': 9, '10': 'wallet'},
+    {'1': 'requests', '3': 2, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.ImportDescriptorsRequest.Request', '10': 'requests'},
+  ],
+  '3': [ImportDescriptorsRequest_Request$json],
+};
+
+@$core.Deprecated('Use importDescriptorsRequestDescriptor instead')
+const ImportDescriptorsRequest_Request$json = {
+  '1': 'Request',
+  '2': [
+    {'1': 'descriptor', '3': 1, '4': 1, '5': 9, '10': 'descriptor'},
+    {'1': 'active', '3': 2, '4': 1, '5': 8, '10': 'active'},
+    {'1': 'range_start', '3': 3, '4': 1, '5': 13, '10': 'rangeStart'},
+    {'1': 'range_end', '3': 4, '4': 1, '5': 13, '10': 'rangeEnd'},
+    {'1': 'timestamp', '3': 5, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'timestamp'},
+    {'1': 'internal', '3': 6, '4': 1, '5': 8, '10': 'internal'},
+    {'1': 'label', '3': 7, '4': 1, '5': 9, '10': 'label'},
+  ],
+};
+
+/// Descriptor for `ImportDescriptorsRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List importDescriptorsRequestDescriptor = $convert.base64Decode(
+    'ChhJbXBvcnREZXNjcmlwdG9yc1JlcXVlc3QSFgoGd2FsbGV0GAEgASgJUgZ3YWxsZXQSVgoIcm'
+    'VxdWVzdHMYAiADKAsyOi5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuSW1wb3J0RGVzY3JpcHRv'
+    'cnNSZXF1ZXN0LlJlcXVlc3RSCHJlcXVlc3RzGusBCgdSZXF1ZXN0Eh4KCmRlc2NyaXB0b3IYAS'
+    'ABKAlSCmRlc2NyaXB0b3ISFgoGYWN0aXZlGAIgASgIUgZhY3RpdmUSHwoLcmFuZ2Vfc3RhcnQY'
+    'AyABKA1SCnJhbmdlU3RhcnQSGwoJcmFuZ2VfZW5kGAQgASgNUghyYW5nZUVuZBI4Cgl0aW1lc3'
+    'RhbXAYBSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgl0aW1lc3RhbXASGgoIaW50'
+    'ZXJuYWwYBiABKAhSCGludGVybmFsEhQKBWxhYmVsGAcgASgJUgVsYWJlbA==');
+
+@$core.Deprecated('Use importDescriptorsResponseDescriptor instead')
+const ImportDescriptorsResponse$json = {
+  '1': 'ImportDescriptorsResponse',
+  '2': [
+    {'1': 'responses', '3': 1, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.ImportDescriptorsResponse.Response', '10': 'responses'},
+  ],
+  '3': [ImportDescriptorsResponse_Error$json, ImportDescriptorsResponse_Response$json],
+};
+
+@$core.Deprecated('Use importDescriptorsResponseDescriptor instead')
+const ImportDescriptorsResponse_Error$json = {
+  '1': 'Error',
+  '2': [
+    {'1': 'code', '3': 1, '4': 1, '5': 5, '10': 'code'},
+    {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+  ],
+};
+
+@$core.Deprecated('Use importDescriptorsResponseDescriptor instead')
+const ImportDescriptorsResponse_Response$json = {
+  '1': 'Response',
+  '2': [
+    {'1': 'success', '3': 1, '4': 1, '5': 8, '10': 'success'},
+    {'1': 'warnings', '3': 2, '4': 3, '5': 9, '10': 'warnings'},
+    {'1': 'error', '3': 3, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.ImportDescriptorsResponse.Error', '10': 'error'},
+  ],
+};
+
+/// Descriptor for `ImportDescriptorsResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List importDescriptorsResponseDescriptor = $convert.base64Decode(
+    'ChlJbXBvcnREZXNjcmlwdG9yc1Jlc3BvbnNlEloKCXJlc3BvbnNlcxgBIAMoCzI8LmJpdGNvaW'
+    '4uYml0Y29pbmQudjFhbHBoYS5JbXBvcnREZXNjcmlwdG9yc1Jlc3BvbnNlLlJlc3BvbnNlUgly'
+    'ZXNwb25zZXMaNQoFRXJyb3ISEgoEY29kZRgBIAEoBVIEY29kZRIYCgdtZXNzYWdlGAIgASgJUg'
+    'dtZXNzYWdlGpEBCghSZXNwb25zZRIYCgdzdWNjZXNzGAEgASgIUgdzdWNjZXNzEhoKCHdhcm5p'
+    'bmdzGAIgAygJUgh3YXJuaW5ncxJPCgVlcnJvchgDIAEoCzI5LmJpdGNvaW4uYml0Y29pbmQudj'
+    'FhbHBoYS5JbXBvcnREZXNjcmlwdG9yc1Jlc3BvbnNlLkVycm9yUgVlcnJvcg==');
+
+@$core.Deprecated('Use getDescriptorInfoRequestDescriptor instead')
+const GetDescriptorInfoRequest$json = {
+  '1': 'GetDescriptorInfoRequest',
+  '2': [
+    {'1': 'descriptor', '3': 1, '4': 1, '5': 9, '10': 'descriptor'},
+  ],
+};
+
+/// Descriptor for `GetDescriptorInfoRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getDescriptorInfoRequestDescriptor = $convert.base64Decode(
+    'ChhHZXREZXNjcmlwdG9ySW5mb1JlcXVlc3QSHgoKZGVzY3JpcHRvchgBIAEoCVIKZGVzY3JpcH'
+    'Rvcg==');
+
+@$core.Deprecated('Use getDescriptorInfoResponseDescriptor instead')
+const GetDescriptorInfoResponse$json = {
+  '1': 'GetDescriptorInfoResponse',
+  '2': [
+    {'1': 'descriptor', '3': 1, '4': 1, '5': 9, '10': 'descriptor'},
+    {'1': 'checksum', '3': 2, '4': 1, '5': 9, '10': 'checksum'},
+    {'1': 'is_range', '3': 3, '4': 1, '5': 8, '10': 'isRange'},
+    {'1': 'is_solvable', '3': 4, '4': 1, '5': 8, '10': 'isSolvable'},
+    {'1': 'has_private_keys', '3': 5, '4': 1, '5': 8, '10': 'hasPrivateKeys'},
+  ],
+};
+
+/// Descriptor for `GetDescriptorInfoResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getDescriptorInfoResponseDescriptor = $convert.base64Decode(
+    'ChlHZXREZXNjcmlwdG9ySW5mb1Jlc3BvbnNlEh4KCmRlc2NyaXB0b3IYASABKAlSCmRlc2NyaX'
+    'B0b3ISGgoIY2hlY2tzdW0YAiABKAlSCGNoZWNrc3VtEhkKCGlzX3JhbmdlGAMgASgIUgdpc1Jh'
+    'bmdlEh8KC2lzX3NvbHZhYmxlGAQgASgIUgppc1NvbHZhYmxlEigKEGhhc19wcml2YXRlX2tleX'
+    'MYBSABKAhSDmhhc1ByaXZhdGVLZXlz');
+
+@$core.Deprecated('Use getBlockRequestDescriptor instead')
+const GetBlockRequest$json = {
+  '1': 'GetBlockRequest',
+  '2': [
+    {'1': 'hash', '3': 1, '4': 1, '5': 9, '10': 'hash'},
+    {'1': 'verbosity', '3': 2, '4': 1, '5': 14, '6': '.bitcoin.bitcoind.v1alpha.GetBlockRequest.Verbosity', '10': 'verbosity'},
+  ],
+  '4': [GetBlockRequest_Verbosity$json],
+};
+
+@$core.Deprecated('Use getBlockRequestDescriptor instead')
+const GetBlockRequest_Verbosity$json = {
+  '1': 'Verbosity',
+  '2': [
+    {'1': 'VERBOSITY_UNSPECIFIED', '2': 0},
+    {'1': 'VERBOSITY_RAW_DATA', '2': 1},
+    {'1': 'VERBOSITY_BLOCK_INFO', '2': 2},
+    {'1': 'VERBOSITY_BLOCK_TX_INFO', '2': 3},
+    {'1': 'VERBOSITY_BLOCK_TX_PREVOUT_INFO', '2': 4},
+  ],
+};
+
+/// Descriptor for `GetBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBlockRequestDescriptor = $convert.base64Decode(
+    'Cg9HZXRCbG9ja1JlcXVlc3QSEgoEaGFzaBgBIAEoCVIEaGFzaBJRCgl2ZXJib3NpdHkYAiABKA'
+    '4yMy5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuR2V0QmxvY2tSZXF1ZXN0LlZlcmJvc2l0eVIJ'
+    'dmVyYm9zaXR5IpoBCglWZXJib3NpdHkSGQoVVkVSQk9TSVRZX1VOU1BFQ0lGSUVEEAASFgoSVk'
+    'VSQk9TSVRZX1JBV19EQVRBEAESGAoUVkVSQk9TSVRZX0JMT0NLX0lORk8QAhIbChdWRVJCT1NJ'
+    'VFlfQkxPQ0tfVFhfSU5GTxADEiMKH1ZFUkJPU0lUWV9CTE9DS19UWF9QUkVWT1VUX0lORk8QBA'
+    '==');
+
+@$core.Deprecated('Use getBlockResponseDescriptor instead')
+const GetBlockResponse$json = {
+  '1': 'GetBlockResponse',
+  '2': [
+    {'1': 'hex', '3': 1, '4': 1, '5': 9, '10': 'hex'},
+    {'1': 'hash', '3': 2, '4': 1, '5': 9, '10': 'hash'},
+    {'1': 'confirmations', '3': 3, '4': 1, '5': 5, '10': 'confirmations'},
+    {'1': 'height', '3': 4, '4': 1, '5': 13, '10': 'height'},
+    {'1': 'version', '3': 5, '4': 1, '5': 5, '10': 'version'},
+    {'1': 'version_hex', '3': 6, '4': 1, '5': 9, '10': 'versionHex'},
+    {'1': 'merkle_root', '3': 7, '4': 1, '5': 9, '10': 'merkleRoot'},
+    {'1': 'time', '3': 8, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'time'},
+    {'1': 'nonce', '3': 9, '4': 1, '5': 13, '10': 'nonce'},
+    {'1': 'bits', '3': 10, '4': 1, '5': 9, '10': 'bits'},
+    {'1': 'difficulty', '3': 11, '4': 1, '5': 1, '10': 'difficulty'},
+    {'1': 'previous_block_hash', '3': 12, '4': 1, '5': 9, '10': 'previousBlockHash'},
+    {'1': 'next_block_hash', '3': 13, '4': 1, '5': 9, '10': 'nextBlockHash'},
+    {'1': 'stripped_size', '3': 14, '4': 1, '5': 5, '10': 'strippedSize'},
+    {'1': 'size', '3': 15, '4': 1, '5': 5, '10': 'size'},
+    {'1': 'weight', '3': 16, '4': 1, '5': 5, '10': 'weight'},
+    {'1': 'txids', '3': 17, '4': 3, '5': 9, '10': 'txids'},
+  ],
+};
+
+/// Descriptor for `GetBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBlockResponseDescriptor = $convert.base64Decode(
+    'ChBHZXRCbG9ja1Jlc3BvbnNlEhAKA2hleBgBIAEoCVIDaGV4EhIKBGhhc2gYAiABKAlSBGhhc2'
+    'gSJAoNY29uZmlybWF0aW9ucxgDIAEoBVINY29uZmlybWF0aW9ucxIWCgZoZWlnaHQYBCABKA1S'
+    'BmhlaWdodBIYCgd2ZXJzaW9uGAUgASgFUgd2ZXJzaW9uEh8KC3ZlcnNpb25faGV4GAYgASgJUg'
+    'p2ZXJzaW9uSGV4Eh8KC21lcmtsZV9yb290GAcgASgJUgptZXJrbGVSb290Ei4KBHRpbWUYCCAB'
+    'KAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUgR0aW1lEhQKBW5vbmNlGAkgASgNUgVub2'
+    '5jZRISCgRiaXRzGAogASgJUgRiaXRzEh4KCmRpZmZpY3VsdHkYCyABKAFSCmRpZmZpY3VsdHkS'
+    'LgoTcHJldmlvdXNfYmxvY2tfaGFzaBgMIAEoCVIRcHJldmlvdXNCbG9ja0hhc2gSJgoPbmV4dF'
+    '9ibG9ja19oYXNoGA0gASgJUg1uZXh0QmxvY2tIYXNoEiMKDXN0cmlwcGVkX3NpemUYDiABKAVS'
+    'DHN0cmlwcGVkU2l6ZRISCgRzaXplGA8gASgFUgRzaXplEhYKBndlaWdodBgQIAEoBVIGd2VpZ2'
+    'h0EhQKBXR4aWRzGBEgAygJUgV0eGlkcw==');
+
+@$core.Deprecated('Use bumpFeeRequestDescriptor instead')
+const BumpFeeRequest$json = {
+  '1': 'BumpFeeRequest',
+  '2': [
+    {'1': 'wallet', '3': 1, '4': 1, '5': 9, '10': 'wallet'},
+    {'1': 'txid', '3': 2, '4': 1, '5': 9, '10': 'txid'},
+  ],
+};
+
+/// Descriptor for `BumpFeeRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bumpFeeRequestDescriptor = $convert.base64Decode(
+    'Cg5CdW1wRmVlUmVxdWVzdBIWCgZ3YWxsZXQYASABKAlSBndhbGxldBISCgR0eGlkGAIgASgJUg'
+    'R0eGlk');
+
+@$core.Deprecated('Use bumpFeeResponseDescriptor instead')
+const BumpFeeResponse$json = {
+  '1': 'BumpFeeResponse',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'original_fee', '3': 2, '4': 1, '5': 1, '10': 'originalFee'},
+    {'1': 'new_fee', '3': 3, '4': 1, '5': 1, '10': 'newFee'},
+    {'1': 'errors', '3': 4, '4': 3, '5': 9, '10': 'errors'},
+  ],
+};
+
+/// Descriptor for `BumpFeeResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bumpFeeResponseDescriptor = $convert.base64Decode(
+    'Cg9CdW1wRmVlUmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZBIhCgxvcmlnaW5hbF9mZWUYAi'
+    'ABKAFSC29yaWdpbmFsRmVlEhcKB25ld19mZWUYAyABKAFSBm5ld0ZlZRIWCgZlcnJvcnMYBCAD'
+    'KAlSBmVycm9ycw==');
+
+@$core.Deprecated('Use listSinceBlockRequestDescriptor instead')
+const ListSinceBlockRequest$json = {
+  '1': 'ListSinceBlockRequest',
+  '2': [
+    {'1': 'wallet', '3': 1, '4': 1, '5': 9, '10': 'wallet'},
+    {'1': 'hash', '3': 2, '4': 1, '5': 9, '10': 'hash'},
+  ],
+};
+
+/// Descriptor for `ListSinceBlockRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List listSinceBlockRequestDescriptor = $convert.base64Decode(
+    'ChVMaXN0U2luY2VCbG9ja1JlcXVlc3QSFgoGd2FsbGV0GAEgASgJUgZ3YWxsZXQSEgoEaGFzaB'
+    'gCIAEoCVIEaGFzaA==');
+
+@$core.Deprecated('Use listSinceBlockResponseDescriptor instead')
+const ListSinceBlockResponse$json = {
+  '1': 'ListSinceBlockResponse',
+  '2': [
+    {'1': 'transactions', '3': 1, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.GetTransactionResponse', '10': 'transactions'},
+  ],
+};
+
+/// Descriptor for `ListSinceBlockResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List listSinceBlockResponseDescriptor = $convert.base64Decode(
+    'ChZMaXN0U2luY2VCbG9ja1Jlc3BvbnNlElQKDHRyYW5zYWN0aW9ucxgBIAMoCzIwLmJpdGNvaW'
+    '4uYml0Y29pbmQudjFhbHBoYS5HZXRUcmFuc2FjdGlvblJlc3BvbnNlUgx0cmFuc2FjdGlvbnM=');
+
+@$core.Deprecated('Use getRawMempoolRequestDescriptor instead')
+const GetRawMempoolRequest$json = {
+  '1': 'GetRawMempoolRequest',
+  '2': [
+    {'1': 'verbose', '3': 1, '4': 1, '5': 8, '10': 'verbose'},
+  ],
+};
+
+/// Descriptor for `GetRawMempoolRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getRawMempoolRequestDescriptor = $convert.base64Decode(
+    'ChRHZXRSYXdNZW1wb29sUmVxdWVzdBIYCgd2ZXJib3NlGAEgASgIUgd2ZXJib3Nl');
+
+@$core.Deprecated('Use mempoolEntryDescriptor instead')
+const MempoolEntry$json = {
+  '1': 'MempoolEntry',
+  '2': [
+    {'1': 'virtual_size', '3': 1, '4': 1, '5': 13, '10': 'virtualSize'},
+    {'1': 'weight', '3': 2, '4': 1, '5': 13, '10': 'weight'},
+    {'1': 'time', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'time'},
+    {'1': 'descendant_count', '3': 4, '4': 1, '5': 13, '10': 'descendantCount'},
+    {'1': 'descendant_size', '3': 5, '4': 1, '5': 13, '10': 'descendantSize'},
+    {'1': 'ancestor_count', '3': 6, '4': 1, '5': 13, '10': 'ancestorCount'},
+    {'1': 'ancestor_size', '3': 7, '4': 1, '5': 13, '10': 'ancestorSize'},
+    {'1': 'witness_txid', '3': 8, '4': 1, '5': 9, '10': 'witnessTxid'},
+    {'1': 'fees', '3': 9, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.MempoolEntry.Fees', '10': 'fees'},
+    {'1': 'depends', '3': 10, '4': 3, '5': 9, '10': 'depends'},
+    {'1': 'spent_by', '3': 11, '4': 3, '5': 9, '10': 'spentBy'},
+    {'1': 'bip125_replaceable', '3': 12, '4': 1, '5': 8, '10': 'bip125Replaceable'},
+    {'1': 'unbroadcast', '3': 13, '4': 1, '5': 8, '10': 'unbroadcast'},
+  ],
+  '3': [MempoolEntry_Fees$json],
+};
+
+@$core.Deprecated('Use mempoolEntryDescriptor instead')
+const MempoolEntry_Fees$json = {
+  '1': 'Fees',
+  '2': [
+    {'1': 'base', '3': 1, '4': 1, '5': 1, '10': 'base'},
+    {'1': 'modified', '3': 2, '4': 1, '5': 1, '10': 'modified'},
+    {'1': 'ancestor', '3': 3, '4': 1, '5': 1, '10': 'ancestor'},
+    {'1': 'descendant', '3': 4, '4': 1, '5': 1, '10': 'descendant'},
+  ],
+};
+
+/// Descriptor for `MempoolEntry`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List mempoolEntryDescriptor = $convert.base64Decode(
+    'CgxNZW1wb29sRW50cnkSIQoMdmlydHVhbF9zaXplGAEgASgNUgt2aXJ0dWFsU2l6ZRIWCgZ3ZW'
+    'lnaHQYAiABKA1SBndlaWdodBIuCgR0aW1lGAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVz'
+    'dGFtcFIEdGltZRIpChBkZXNjZW5kYW50X2NvdW50GAQgASgNUg9kZXNjZW5kYW50Q291bnQSJw'
+    'oPZGVzY2VuZGFudF9zaXplGAUgASgNUg5kZXNjZW5kYW50U2l6ZRIlCg5hbmNlc3Rvcl9jb3Vu'
+    'dBgGIAEoDVINYW5jZXN0b3JDb3VudBIjCg1hbmNlc3Rvcl9zaXplGAcgASgNUgxhbmNlc3Rvcl'
+    'NpemUSIQoMd2l0bmVzc190eGlkGAggASgJUgt3aXRuZXNzVHhpZBI/CgRmZWVzGAkgASgLMisu'
+    'Yml0Y29pbi5iaXRjb2luZC52MWFscGhhLk1lbXBvb2xFbnRyeS5GZWVzUgRmZWVzEhgKB2RlcG'
+    'VuZHMYCiADKAlSB2RlcGVuZHMSGQoIc3BlbnRfYnkYCyADKAlSB3NwZW50QnkSLQoSYmlwMTI1'
+    'X3JlcGxhY2VhYmxlGAwgASgIUhFiaXAxMjVSZXBsYWNlYWJsZRIgCgt1bmJyb2FkY2FzdBgNIA'
+    'EoCFILdW5icm9hZGNhc3QacgoERmVlcxISCgRiYXNlGAEgASgBUgRiYXNlEhoKCG1vZGlmaWVk'
+    'GAIgASgBUghtb2RpZmllZBIaCghhbmNlc3RvchgDIAEoAVIIYW5jZXN0b3ISHgoKZGVzY2VuZG'
+    'FudBgEIAEoAVIKZGVzY2VuZGFudA==');
+
+@$core.Deprecated('Use getRawMempoolResponseDescriptor instead')
+const GetRawMempoolResponse$json = {
+  '1': 'GetRawMempoolResponse',
+  '2': [
+    {'1': 'txids', '3': 1, '4': 3, '5': 9, '10': 'txids'},
+    {'1': 'transactions', '3': 2, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.GetRawMempoolResponse.TransactionsEntry', '10': 'transactions'},
+  ],
+  '3': [GetRawMempoolResponse_TransactionsEntry$json],
+};
+
+@$core.Deprecated('Use getRawMempoolResponseDescriptor instead')
+const GetRawMempoolResponse_TransactionsEntry$json = {
+  '1': 'TransactionsEntry',
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.MempoolEntry', '10': 'value'},
+  ],
+  '7': {'7': true},
+};
+
+/// Descriptor for `GetRawMempoolResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getRawMempoolResponseDescriptor = $convert.base64Decode(
+    'ChVHZXRSYXdNZW1wb29sUmVzcG9uc2USFAoFdHhpZHMYASADKAlSBXR4aWRzEmUKDHRyYW5zYW'
+    'N0aW9ucxgCIAMoCzJBLmJpdGNvaW4uYml0Y29pbmQudjFhbHBoYS5HZXRSYXdNZW1wb29sUmVz'
+    'cG9uc2UuVHJhbnNhY3Rpb25zRW50cnlSDHRyYW5zYWN0aW9ucxpnChFUcmFuc2FjdGlvbnNFbn'
+    'RyeRIQCgNrZXkYASABKAlSA2tleRI8CgV2YWx1ZRgCIAEoCzImLmJpdGNvaW4uYml0Y29pbmQu'
+    'djFhbHBoYS5NZW1wb29sRW50cnlSBXZhbHVlOgI4AQ==');
+
+@$core.Deprecated('Use getBlockHashRequestDescriptor instead')
+const GetBlockHashRequest$json = {
+  '1': 'GetBlockHashRequest',
+  '2': [
+    {'1': 'height', '3': 1, '4': 1, '5': 13, '10': 'height'},
+  ],
+};
+
+/// Descriptor for `GetBlockHashRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBlockHashRequestDescriptor = $convert.base64Decode(
+    'ChNHZXRCbG9ja0hhc2hSZXF1ZXN0EhYKBmhlaWdodBgBIAEoDVIGaGVpZ2h0');
+
+@$core.Deprecated('Use getBlockHashResponseDescriptor instead')
+const GetBlockHashResponse$json = {
+  '1': 'GetBlockHashResponse',
+  '2': [
+    {'1': 'hash', '3': 1, '4': 1, '5': 9, '10': 'hash'},
+  ],
+};
+
+/// Descriptor for `GetBlockHashResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getBlockHashResponseDescriptor = $convert.base64Decode(
+    'ChRHZXRCbG9ja0hhc2hSZXNwb25zZRISCgRoYXNoGAEgASgJUgRoYXNo');
+
+@$core.Deprecated('Use listTransactionsRequestDescriptor instead')
+const ListTransactionsRequest$json = {
+  '1': 'ListTransactionsRequest',
+  '2': [
+    {'1': 'wallet', '3': 1, '4': 1, '5': 9, '10': 'wallet'},
+    {'1': 'count', '3': 2, '4': 1, '5': 13, '10': 'count'},
+    {'1': 'skip', '3': 3, '4': 1, '5': 13, '10': 'skip'},
+  ],
+};
+
+/// Descriptor for `ListTransactionsRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List listTransactionsRequestDescriptor = $convert.base64Decode(
+    'ChdMaXN0VHJhbnNhY3Rpb25zUmVxdWVzdBIWCgZ3YWxsZXQYASABKAlSBndhbGxldBIUCgVjb3'
+    'VudBgCIAEoDVIFY291bnQSEgoEc2tpcBgDIAEoDVIEc2tpcA==');
+
+@$core.Deprecated('Use listTransactionsResponseDescriptor instead')
+const ListTransactionsResponse$json = {
+  '1': 'ListTransactionsResponse',
+  '2': [
+    {'1': 'transactions', '3': 1, '4': 3, '5': 11, '6': '.bitcoin.bitcoind.v1alpha.GetTransactionResponse', '10': 'transactions'},
+  ],
+};
+
+/// Descriptor for `ListTransactionsResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List listTransactionsResponseDescriptor = $convert.base64Decode(
+    'ChhMaXN0VHJhbnNhY3Rpb25zUmVzcG9uc2USVAoMdHJhbnNhY3Rpb25zGAEgAygLMjAuYml0Y2'
+    '9pbi5iaXRjb2luZC52MWFscGhhLkdldFRyYW5zYWN0aW9uUmVzcG9uc2VSDHRyYW5zYWN0aW9u'
+    'cw==');
+
+const $core.Map<$core.String, $core.dynamic> BitcoinServiceBase$json = {
+  '1': 'BitcoinService',
+  '2': [
+    {'1': 'GetBlockchainInfo', '2': '.bitcoin.bitcoind.v1alpha.GetBlockchainInfoRequest', '3': '.bitcoin.bitcoind.v1alpha.GetBlockchainInfoResponse'},
+    {'1': 'GetTransaction', '2': '.bitcoin.bitcoind.v1alpha.GetTransactionRequest', '3': '.bitcoin.bitcoind.v1alpha.GetTransactionResponse'},
+    {'1': 'ListSinceBlock', '2': '.bitcoin.bitcoind.v1alpha.ListSinceBlockRequest', '3': '.bitcoin.bitcoind.v1alpha.ListSinceBlockResponse'},
+    {'1': 'GetNewAddress', '2': '.bitcoin.bitcoind.v1alpha.GetNewAddressRequest', '3': '.bitcoin.bitcoind.v1alpha.GetNewAddressResponse'},
+    {'1': 'GetWalletInfo', '2': '.bitcoin.bitcoind.v1alpha.GetWalletInfoRequest', '3': '.bitcoin.bitcoind.v1alpha.GetWalletInfoResponse'},
+    {'1': 'GetBalances', '2': '.bitcoin.bitcoind.v1alpha.GetBalancesRequest', '3': '.bitcoin.bitcoind.v1alpha.GetBalancesResponse'},
+    {'1': 'Send', '2': '.bitcoin.bitcoind.v1alpha.SendRequest', '3': '.bitcoin.bitcoind.v1alpha.SendResponse'},
+    {'1': 'SendToAddress', '2': '.bitcoin.bitcoind.v1alpha.SendToAddressRequest', '3': '.bitcoin.bitcoind.v1alpha.SendToAddressResponse'},
+    {'1': 'BumpFee', '2': '.bitcoin.bitcoind.v1alpha.BumpFeeRequest', '3': '.bitcoin.bitcoind.v1alpha.BumpFeeResponse'},
+    {'1': 'EstimateSmartFee', '2': '.bitcoin.bitcoind.v1alpha.EstimateSmartFeeRequest', '3': '.bitcoin.bitcoind.v1alpha.EstimateSmartFeeResponse'},
+    {'1': 'ImportDescriptors', '2': '.bitcoin.bitcoind.v1alpha.ImportDescriptorsRequest', '3': '.bitcoin.bitcoind.v1alpha.ImportDescriptorsResponse'},
+    {'1': 'ListTransactions', '2': '.bitcoin.bitcoind.v1alpha.ListTransactionsRequest', '3': '.bitcoin.bitcoind.v1alpha.ListTransactionsResponse'},
+    {'1': 'GetDescriptorInfo', '2': '.bitcoin.bitcoind.v1alpha.GetDescriptorInfoRequest', '3': '.bitcoin.bitcoind.v1alpha.GetDescriptorInfoResponse'},
+    {'1': 'GetRawMempool', '2': '.bitcoin.bitcoind.v1alpha.GetRawMempoolRequest', '3': '.bitcoin.bitcoind.v1alpha.GetRawMempoolResponse'},
+    {'1': 'GetRawTransaction', '2': '.bitcoin.bitcoind.v1alpha.GetRawTransactionRequest', '3': '.bitcoin.bitcoind.v1alpha.GetRawTransactionResponse'},
+    {'1': 'DecodeRawTransaction', '2': '.bitcoin.bitcoind.v1alpha.DecodeRawTransactionRequest', '3': '.bitcoin.bitcoind.v1alpha.DecodeRawTransactionResponse'},
+    {'1': 'GetBlock', '2': '.bitcoin.bitcoind.v1alpha.GetBlockRequest', '3': '.bitcoin.bitcoind.v1alpha.GetBlockResponse'},
+    {'1': 'GetBlockHash', '2': '.bitcoin.bitcoind.v1alpha.GetBlockHashRequest', '3': '.bitcoin.bitcoind.v1alpha.GetBlockHashResponse'},
+  ],
+};
+
+@$core.Deprecated('Use bitcoinServiceDescriptor instead')
+const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> BitcoinServiceBase$messageJson = {
+  '.bitcoin.bitcoind.v1alpha.GetBlockchainInfoRequest': GetBlockchainInfoRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetBlockchainInfoResponse': GetBlockchainInfoResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetTransactionRequest': GetTransactionRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetTransactionResponse': GetTransactionResponse$json,
+  '.google.protobuf.Timestamp': $0.Timestamp$json,
+  '.bitcoin.bitcoind.v1alpha.GetTransactionResponse.Details': GetTransactionResponse_Details$json,
+  '.bitcoin.bitcoind.v1alpha.ListSinceBlockRequest': ListSinceBlockRequest$json,
+  '.bitcoin.bitcoind.v1alpha.ListSinceBlockResponse': ListSinceBlockResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetNewAddressRequest': GetNewAddressRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetNewAddressResponse': GetNewAddressResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetWalletInfoRequest': GetWalletInfoRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetWalletInfoResponse': GetWalletInfoResponse$json,
+  '.bitcoin.bitcoind.v1alpha.WalletScan': WalletScan$json,
+  '.bitcoin.bitcoind.v1alpha.GetBalancesRequest': GetBalancesRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetBalancesResponse': GetBalancesResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetBalancesResponse.Mine': GetBalancesResponse_Mine$json,
+  '.bitcoin.bitcoind.v1alpha.GetBalancesResponse.Watchonly': GetBalancesResponse_Watchonly$json,
+  '.bitcoin.bitcoind.v1alpha.SendRequest': SendRequest$json,
+  '.bitcoin.bitcoind.v1alpha.SendRequest.DestinationsEntry': SendRequest_DestinationsEntry$json,
+  '.google.protobuf.BoolValue': $1.BoolValue$json,
+  '.bitcoin.bitcoind.v1alpha.SendResponse': SendResponse$json,
+  '.bitcoin.bitcoind.v1alpha.RawTransaction': RawTransaction$json,
+  '.bitcoin.bitcoind.v1alpha.SendToAddressRequest': SendToAddressRequest$json,
+  '.bitcoin.bitcoind.v1alpha.SendToAddressResponse': SendToAddressResponse$json,
+  '.bitcoin.bitcoind.v1alpha.BumpFeeRequest': BumpFeeRequest$json,
+  '.bitcoin.bitcoind.v1alpha.BumpFeeResponse': BumpFeeResponse$json,
+  '.bitcoin.bitcoind.v1alpha.EstimateSmartFeeRequest': EstimateSmartFeeRequest$json,
+  '.bitcoin.bitcoind.v1alpha.EstimateSmartFeeResponse': EstimateSmartFeeResponse$json,
+  '.bitcoin.bitcoind.v1alpha.ImportDescriptorsRequest': ImportDescriptorsRequest$json,
+  '.bitcoin.bitcoind.v1alpha.ImportDescriptorsRequest.Request': ImportDescriptorsRequest_Request$json,
+  '.bitcoin.bitcoind.v1alpha.ImportDescriptorsResponse': ImportDescriptorsResponse$json,
+  '.bitcoin.bitcoind.v1alpha.ImportDescriptorsResponse.Response': ImportDescriptorsResponse_Response$json,
+  '.bitcoin.bitcoind.v1alpha.ImportDescriptorsResponse.Error': ImportDescriptorsResponse_Error$json,
+  '.bitcoin.bitcoind.v1alpha.ListTransactionsRequest': ListTransactionsRequest$json,
+  '.bitcoin.bitcoind.v1alpha.ListTransactionsResponse': ListTransactionsResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetDescriptorInfoRequest': GetDescriptorInfoRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetDescriptorInfoResponse': GetDescriptorInfoResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetRawMempoolRequest': GetRawMempoolRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetRawMempoolResponse': GetRawMempoolResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetRawMempoolResponse.TransactionsEntry': GetRawMempoolResponse_TransactionsEntry$json,
+  '.bitcoin.bitcoind.v1alpha.MempoolEntry': MempoolEntry$json,
+  '.bitcoin.bitcoind.v1alpha.MempoolEntry.Fees': MempoolEntry_Fees$json,
+  '.bitcoin.bitcoind.v1alpha.GetRawTransactionRequest': GetRawTransactionRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetRawTransactionResponse': GetRawTransactionResponse$json,
+  '.bitcoin.bitcoind.v1alpha.Input': Input$json,
+  '.bitcoin.bitcoind.v1alpha.Output': Output$json,
+  '.bitcoin.bitcoind.v1alpha.ScriptPubKey': ScriptPubKey$json,
+  '.bitcoin.bitcoind.v1alpha.DecodeRawTransactionRequest': DecodeRawTransactionRequest$json,
+  '.bitcoin.bitcoind.v1alpha.DecodeRawTransactionResponse': DecodeRawTransactionResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetBlockRequest': GetBlockRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetBlockResponse': GetBlockResponse$json,
+  '.bitcoin.bitcoind.v1alpha.GetBlockHashRequest': GetBlockHashRequest$json,
+  '.bitcoin.bitcoind.v1alpha.GetBlockHashResponse': GetBlockHashResponse$json,
+};
+
+/// Descriptor for `BitcoinService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
+final $typed_data.Uint8List bitcoinServiceDescriptor = $convert.base64Decode(
+    'Cg5CaXRjb2luU2VydmljZRJ8ChFHZXRCbG9ja2NoYWluSW5mbxIyLmJpdGNvaW4uYml0Y29pbm'
+    'QudjFhbHBoYS5HZXRCbG9ja2NoYWluSW5mb1JlcXVlc3QaMy5iaXRjb2luLmJpdGNvaW5kLnYx'
+    'YWxwaGEuR2V0QmxvY2tjaGFpbkluZm9SZXNwb25zZRJzCg5HZXRUcmFuc2FjdGlvbhIvLmJpdG'
+    'NvaW4uYml0Y29pbmQudjFhbHBoYS5HZXRUcmFuc2FjdGlvblJlcXVlc3QaMC5iaXRjb2luLmJp'
+    'dGNvaW5kLnYxYWxwaGEuR2V0VHJhbnNhY3Rpb25SZXNwb25zZRJzCg5MaXN0U2luY2VCbG9jax'
+    'IvLmJpdGNvaW4uYml0Y29pbmQudjFhbHBoYS5MaXN0U2luY2VCbG9ja1JlcXVlc3QaMC5iaXRj'
+    'b2luLmJpdGNvaW5kLnYxYWxwaGEuTGlzdFNpbmNlQmxvY2tSZXNwb25zZRJwCg1HZXROZXdBZG'
+    'RyZXNzEi4uYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldE5ld0FkZHJlc3NSZXF1ZXN0Gi8u'
+    'Yml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldE5ld0FkZHJlc3NSZXNwb25zZRJwCg1HZXRXYW'
+    'xsZXRJbmZvEi4uYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldFdhbGxldEluZm9SZXF1ZXN0'
+    'Gi8uYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldFdhbGxldEluZm9SZXNwb25zZRJqCgtHZX'
+    'RCYWxhbmNlcxIsLmJpdGNvaW4uYml0Y29pbmQudjFhbHBoYS5HZXRCYWxhbmNlc1JlcXVlc3Qa'
+    'LS5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuR2V0QmFsYW5jZXNSZXNwb25zZRJVCgRTZW5kEi'
+    'UuYml0Y29pbi5iaXRjb2luZC52MWFscGhhLlNlbmRSZXF1ZXN0GiYuYml0Y29pbi5iaXRjb2lu'
+    'ZC52MWFscGhhLlNlbmRSZXNwb25zZRJwCg1TZW5kVG9BZGRyZXNzEi4uYml0Y29pbi5iaXRjb2'
+    'luZC52MWFscGhhLlNlbmRUb0FkZHJlc3NSZXF1ZXN0Gi8uYml0Y29pbi5iaXRjb2luZC52MWFs'
+    'cGhhLlNlbmRUb0FkZHJlc3NSZXNwb25zZRJeCgdCdW1wRmVlEiguYml0Y29pbi5iaXRjb2luZC'
+    '52MWFscGhhLkJ1bXBGZWVSZXF1ZXN0GikuYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkJ1bXBG'
+    'ZWVSZXNwb25zZRJ5ChBFc3RpbWF0ZVNtYXJ0RmVlEjEuYml0Y29pbi5iaXRjb2luZC52MWFscG'
+    'hhLkVzdGltYXRlU21hcnRGZWVSZXF1ZXN0GjIuYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkVz'
+    'dGltYXRlU21hcnRGZWVSZXNwb25zZRJ8ChFJbXBvcnREZXNjcmlwdG9ycxIyLmJpdGNvaW4uYm'
+    'l0Y29pbmQudjFhbHBoYS5JbXBvcnREZXNjcmlwdG9yc1JlcXVlc3QaMy5iaXRjb2luLmJpdGNv'
+    'aW5kLnYxYWxwaGEuSW1wb3J0RGVzY3JpcHRvcnNSZXNwb25zZRJ5ChBMaXN0VHJhbnNhY3Rpb2'
+    '5zEjEuYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkxpc3RUcmFuc2FjdGlvbnNSZXF1ZXN0GjIu'
+    'Yml0Y29pbi5iaXRjb2luZC52MWFscGhhLkxpc3RUcmFuc2FjdGlvbnNSZXNwb25zZRJ8ChFHZX'
+    'REZXNjcmlwdG9ySW5mbxIyLmJpdGNvaW4uYml0Y29pbmQudjFhbHBoYS5HZXREZXNjcmlwdG9y'
+    'SW5mb1JlcXVlc3QaMy5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuR2V0RGVzY3JpcHRvckluZm'
+    '9SZXNwb25zZRJwCg1HZXRSYXdNZW1wb29sEi4uYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdl'
+    'dFJhd01lbXBvb2xSZXF1ZXN0Gi8uYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldFJhd01lbX'
+    'Bvb2xSZXNwb25zZRJ8ChFHZXRSYXdUcmFuc2FjdGlvbhIyLmJpdGNvaW4uYml0Y29pbmQudjFh'
+    'bHBoYS5HZXRSYXdUcmFuc2FjdGlvblJlcXVlc3QaMy5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaG'
+    'EuR2V0UmF3VHJhbnNhY3Rpb25SZXNwb25zZRKFAQoURGVjb2RlUmF3VHJhbnNhY3Rpb24SNS5i'
+    'aXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuRGVjb2RlUmF3VHJhbnNhY3Rpb25SZXF1ZXN0GjYuYm'
+    'l0Y29pbi5iaXRjb2luZC52MWFscGhhLkRlY29kZVJhd1RyYW5zYWN0aW9uUmVzcG9uc2USYQoI'
+    'R2V0QmxvY2sSKS5iaXRjb2luLmJpdGNvaW5kLnYxYWxwaGEuR2V0QmxvY2tSZXF1ZXN0GiouYm'
+    'l0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldEJsb2NrUmVzcG9uc2USbQoMR2V0QmxvY2tIYXNo'
+    'Ei0uYml0Y29pbi5iaXRjb2luZC52MWFscGhhLkdldEJsb2NrSGFzaFJlcXVlc3QaLi5iaXRjb2'
+    'luLmJpdGNvaW5kLnYxYWxwaGEuR2V0QmxvY2tIYXNoUmVzcG9uc2U=');
+

--- a/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbserver.dart
+++ b/packages/faucet/lib/gen/bitcoin/bitcoind/v1alpha/bitcoin.pbserver.dart
@@ -1,0 +1,94 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/bitcoind/v1alpha/bitcoin.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:async' as $async;
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'bitcoin.pb.dart' as $2;
+import 'bitcoin.pbjson.dart';
+
+export 'bitcoin.pb.dart';
+
+abstract class BitcoinServiceBase extends $pb.GeneratedService {
+  $async.Future<$2.GetBlockchainInfoResponse> getBlockchainInfo($pb.ServerContext ctx, $2.GetBlockchainInfoRequest request);
+  $async.Future<$2.GetTransactionResponse> getTransaction($pb.ServerContext ctx, $2.GetTransactionRequest request);
+  $async.Future<$2.ListSinceBlockResponse> listSinceBlock($pb.ServerContext ctx, $2.ListSinceBlockRequest request);
+  $async.Future<$2.GetNewAddressResponse> getNewAddress($pb.ServerContext ctx, $2.GetNewAddressRequest request);
+  $async.Future<$2.GetWalletInfoResponse> getWalletInfo($pb.ServerContext ctx, $2.GetWalletInfoRequest request);
+  $async.Future<$2.GetBalancesResponse> getBalances($pb.ServerContext ctx, $2.GetBalancesRequest request);
+  $async.Future<$2.SendResponse> send($pb.ServerContext ctx, $2.SendRequest request);
+  $async.Future<$2.SendToAddressResponse> sendToAddress($pb.ServerContext ctx, $2.SendToAddressRequest request);
+  $async.Future<$2.BumpFeeResponse> bumpFee($pb.ServerContext ctx, $2.BumpFeeRequest request);
+  $async.Future<$2.EstimateSmartFeeResponse> estimateSmartFee($pb.ServerContext ctx, $2.EstimateSmartFeeRequest request);
+  $async.Future<$2.ImportDescriptorsResponse> importDescriptors($pb.ServerContext ctx, $2.ImportDescriptorsRequest request);
+  $async.Future<$2.ListTransactionsResponse> listTransactions($pb.ServerContext ctx, $2.ListTransactionsRequest request);
+  $async.Future<$2.GetDescriptorInfoResponse> getDescriptorInfo($pb.ServerContext ctx, $2.GetDescriptorInfoRequest request);
+  $async.Future<$2.GetRawMempoolResponse> getRawMempool($pb.ServerContext ctx, $2.GetRawMempoolRequest request);
+  $async.Future<$2.GetRawTransactionResponse> getRawTransaction($pb.ServerContext ctx, $2.GetRawTransactionRequest request);
+  $async.Future<$2.DecodeRawTransactionResponse> decodeRawTransaction($pb.ServerContext ctx, $2.DecodeRawTransactionRequest request);
+  $async.Future<$2.GetBlockResponse> getBlock($pb.ServerContext ctx, $2.GetBlockRequest request);
+  $async.Future<$2.GetBlockHashResponse> getBlockHash($pb.ServerContext ctx, $2.GetBlockHashRequest request);
+
+  $pb.GeneratedMessage createRequest($core.String methodName) {
+    switch (methodName) {
+      case 'GetBlockchainInfo': return $2.GetBlockchainInfoRequest();
+      case 'GetTransaction': return $2.GetTransactionRequest();
+      case 'ListSinceBlock': return $2.ListSinceBlockRequest();
+      case 'GetNewAddress': return $2.GetNewAddressRequest();
+      case 'GetWalletInfo': return $2.GetWalletInfoRequest();
+      case 'GetBalances': return $2.GetBalancesRequest();
+      case 'Send': return $2.SendRequest();
+      case 'SendToAddress': return $2.SendToAddressRequest();
+      case 'BumpFee': return $2.BumpFeeRequest();
+      case 'EstimateSmartFee': return $2.EstimateSmartFeeRequest();
+      case 'ImportDescriptors': return $2.ImportDescriptorsRequest();
+      case 'ListTransactions': return $2.ListTransactionsRequest();
+      case 'GetDescriptorInfo': return $2.GetDescriptorInfoRequest();
+      case 'GetRawMempool': return $2.GetRawMempoolRequest();
+      case 'GetRawTransaction': return $2.GetRawTransactionRequest();
+      case 'DecodeRawTransaction': return $2.DecodeRawTransactionRequest();
+      case 'GetBlock': return $2.GetBlockRequest();
+      case 'GetBlockHash': return $2.GetBlockHashRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
+    }
+  }
+
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+    switch (methodName) {
+      case 'GetBlockchainInfo': return this.getBlockchainInfo(ctx, request as $2.GetBlockchainInfoRequest);
+      case 'GetTransaction': return this.getTransaction(ctx, request as $2.GetTransactionRequest);
+      case 'ListSinceBlock': return this.listSinceBlock(ctx, request as $2.ListSinceBlockRequest);
+      case 'GetNewAddress': return this.getNewAddress(ctx, request as $2.GetNewAddressRequest);
+      case 'GetWalletInfo': return this.getWalletInfo(ctx, request as $2.GetWalletInfoRequest);
+      case 'GetBalances': return this.getBalances(ctx, request as $2.GetBalancesRequest);
+      case 'Send': return this.send(ctx, request as $2.SendRequest);
+      case 'SendToAddress': return this.sendToAddress(ctx, request as $2.SendToAddressRequest);
+      case 'BumpFee': return this.bumpFee(ctx, request as $2.BumpFeeRequest);
+      case 'EstimateSmartFee': return this.estimateSmartFee(ctx, request as $2.EstimateSmartFeeRequest);
+      case 'ImportDescriptors': return this.importDescriptors(ctx, request as $2.ImportDescriptorsRequest);
+      case 'ListTransactions': return this.listTransactions(ctx, request as $2.ListTransactionsRequest);
+      case 'GetDescriptorInfo': return this.getDescriptorInfo(ctx, request as $2.GetDescriptorInfoRequest);
+      case 'GetRawMempool': return this.getRawMempool(ctx, request as $2.GetRawMempoolRequest);
+      case 'GetRawTransaction': return this.getRawTransaction(ctx, request as $2.GetRawTransactionRequest);
+      case 'DecodeRawTransaction': return this.decodeRawTransaction(ctx, request as $2.DecodeRawTransactionRequest);
+      case 'GetBlock': return this.getBlock(ctx, request as $2.GetBlockRequest);
+      case 'GetBlockHash': return this.getBlockHash(ctx, request as $2.GetBlockHashRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
+    }
+  }
+
+  $core.Map<$core.String, $core.dynamic> get $json => BitcoinServiceBase$json;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => BitcoinServiceBase$messageJson;
+}
+

--- a/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pb.dart
+++ b/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pb.dart
@@ -1,0 +1,167 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/drivechaind/v1/drivechain.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:async' as $async;
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class CreateSidechainDepositRequest extends $pb.GeneratedMessage {
+  factory CreateSidechainDepositRequest({
+    $core.String? destination,
+    $core.double? amount,
+    $core.double? fee,
+  }) {
+    final $result = create();
+    if (destination != null) {
+      $result.destination = destination;
+    }
+    if (amount != null) {
+      $result.amount = amount;
+    }
+    if (fee != null) {
+      $result.fee = fee;
+    }
+    return $result;
+  }
+  CreateSidechainDepositRequest._() : super();
+  factory CreateSidechainDepositRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateSidechainDepositRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateSidechainDepositRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.drivechaind.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'destination')
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'amount', $pb.PbFieldType.OD)
+    ..a<$core.double>(3, _omitFieldNames ? '' : 'fee', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreateSidechainDepositRequest clone() => CreateSidechainDepositRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateSidechainDepositRequest copyWith(void Function(CreateSidechainDepositRequest) updates) => super.copyWith((message) => updates(message as CreateSidechainDepositRequest)) as CreateSidechainDepositRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreateSidechainDepositRequest create() => CreateSidechainDepositRequest._();
+  CreateSidechainDepositRequest createEmptyInstance() => create();
+  static $pb.PbList<CreateSidechainDepositRequest> createRepeated() => $pb.PbList<CreateSidechainDepositRequest>();
+  @$core.pragma('dart2js:noInline')
+  static CreateSidechainDepositRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateSidechainDepositRequest>(create);
+  static CreateSidechainDepositRequest? _defaultInstance;
+
+  /// The sidechain deposit address to send to.
+  @$pb.TagNumber(1)
+  $core.String get destination => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set destination($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDestination() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDestination() => clearField(1);
+
+  /// The amount in BTC to send. eg 0.1
+  @$pb.TagNumber(2)
+  $core.double get amount => $_getN(1);
+  @$pb.TagNumber(2)
+  set amount($core.double v) { $_setDouble(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasAmount() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearAmount() => clearField(2);
+
+  /// The fee in BTC
+  @$pb.TagNumber(3)
+  $core.double get fee => $_getN(2);
+  @$pb.TagNumber(3)
+  set fee($core.double v) { $_setDouble(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFee() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFee() => clearField(3);
+}
+
+class CreateSidechainDepositResponse extends $pb.GeneratedMessage {
+  factory CreateSidechainDepositResponse({
+    $core.String? txid,
+    $core.Iterable<$core.String>? errors,
+  }) {
+    final $result = create();
+    if (txid != null) {
+      $result.txid = txid;
+    }
+    if (errors != null) {
+      $result.errors.addAll(errors);
+    }
+    return $result;
+  }
+  CreateSidechainDepositResponse._() : super();
+  factory CreateSidechainDepositResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateSidechainDepositResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateSidechainDepositResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'bitcoin.drivechaind.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'txid')
+    ..pPS(2, _omitFieldNames ? '' : 'errors')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreateSidechainDepositResponse clone() => CreateSidechainDepositResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateSidechainDepositResponse copyWith(void Function(CreateSidechainDepositResponse) updates) => super.copyWith((message) => updates(message as CreateSidechainDepositResponse)) as CreateSidechainDepositResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreateSidechainDepositResponse create() => CreateSidechainDepositResponse._();
+  CreateSidechainDepositResponse createEmptyInstance() => create();
+  static $pb.PbList<CreateSidechainDepositResponse> createRepeated() => $pb.PbList<CreateSidechainDepositResponse>();
+  @$core.pragma('dart2js:noInline')
+  static CreateSidechainDepositResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateSidechainDepositResponse>(create);
+  static CreateSidechainDepositResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get txid => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set txid($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasTxid() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTxid() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get errors => $_getList(1);
+}
+
+class DrivechainServiceApi {
+  $pb.RpcClient _client;
+  DrivechainServiceApi(this._client);
+
+  $async.Future<CreateSidechainDepositResponse> createSidechainDeposit($pb.ClientContext? ctx, CreateSidechainDepositRequest request) =>
+    _client.invoke<CreateSidechainDepositResponse>(ctx, 'DrivechainService', 'CreateSidechainDeposit', request, CreateSidechainDepositResponse())
+  ;
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbenum.dart
+++ b/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/drivechaind/v1/drivechain.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbgrpc.dart
+++ b/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbgrpc.dart
@@ -1,0 +1,59 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/drivechaind/v1/drivechain.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:async' as $async;
+import 'dart:core' as $core;
+
+import 'package:grpc/service_api.dart' as $grpc;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'drivechain.pb.dart' as $1;
+
+export 'drivechain.pb.dart';
+
+@$pb.GrpcServiceName('bitcoin.drivechaind.v1.DrivechainService')
+class DrivechainServiceClient extends $grpc.Client {
+  static final _$createSidechainDeposit = $grpc.ClientMethod<$1.CreateSidechainDepositRequest, $1.CreateSidechainDepositResponse>(
+      '/bitcoin.drivechaind.v1.DrivechainService/CreateSidechainDeposit',
+      ($1.CreateSidechainDepositRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $1.CreateSidechainDepositResponse.fromBuffer(value));
+
+  DrivechainServiceClient($grpc.ClientChannel channel,
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
+      : super(channel, options: options,
+        interceptors: interceptors);
+
+  $grpc.ResponseFuture<$1.CreateSidechainDepositResponse> createSidechainDeposit($1.CreateSidechainDepositRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$createSidechainDeposit, request, options: options);
+  }
+}
+
+@$pb.GrpcServiceName('bitcoin.drivechaind.v1.DrivechainService')
+abstract class DrivechainServiceBase extends $grpc.Service {
+  $core.String get $name => 'bitcoin.drivechaind.v1.DrivechainService';
+
+  DrivechainServiceBase() {
+    $addMethod($grpc.ServiceMethod<$1.CreateSidechainDepositRequest, $1.CreateSidechainDepositResponse>(
+        'CreateSidechainDeposit',
+        createSidechainDeposit_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $1.CreateSidechainDepositRequest.fromBuffer(value),
+        ($1.CreateSidechainDepositResponse value) => value.writeToBuffer()));
+  }
+
+  $async.Future<$1.CreateSidechainDepositResponse> createSidechainDeposit_Pre($grpc.ServiceCall call, $async.Future<$1.CreateSidechainDepositRequest> request) async {
+    return createSidechainDeposit(call, await request);
+  }
+
+  $async.Future<$1.CreateSidechainDepositResponse> createSidechainDeposit($grpc.ServiceCall call, $1.CreateSidechainDepositRequest request);
+}

--- a/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbjson.dart
+++ b/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbjson.dart
@@ -1,0 +1,63 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/drivechaind/v1/drivechain.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use createSidechainDepositRequestDescriptor instead')
+const CreateSidechainDepositRequest$json = {
+  '1': 'CreateSidechainDepositRequest',
+  '2': [
+    {'1': 'destination', '3': 1, '4': 1, '5': 9, '10': 'destination'},
+    {'1': 'amount', '3': 2, '4': 1, '5': 1, '10': 'amount'},
+    {'1': 'fee', '3': 3, '4': 1, '5': 1, '10': 'fee'},
+  ],
+};
+
+/// Descriptor for `CreateSidechainDepositRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createSidechainDepositRequestDescriptor = $convert.base64Decode(
+    'Ch1DcmVhdGVTaWRlY2hhaW5EZXBvc2l0UmVxdWVzdBIgCgtkZXN0aW5hdGlvbhgBIAEoCVILZG'
+    'VzdGluYXRpb24SFgoGYW1vdW50GAIgASgBUgZhbW91bnQSEAoDZmVlGAMgASgBUgNmZWU=');
+
+@$core.Deprecated('Use createSidechainDepositResponseDescriptor instead')
+const CreateSidechainDepositResponse$json = {
+  '1': 'CreateSidechainDepositResponse',
+  '2': [
+    {'1': 'txid', '3': 1, '4': 1, '5': 9, '10': 'txid'},
+    {'1': 'errors', '3': 2, '4': 3, '5': 9, '10': 'errors'},
+  ],
+};
+
+/// Descriptor for `CreateSidechainDepositResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createSidechainDepositResponseDescriptor = $convert.base64Decode(
+    'Ch5DcmVhdGVTaWRlY2hhaW5EZXBvc2l0UmVzcG9uc2USEgoEdHhpZBgBIAEoCVIEdHhpZBIWCg'
+    'ZlcnJvcnMYAiADKAlSBmVycm9ycw==');
+
+const $core.Map<$core.String, $core.dynamic> DrivechainServiceBase$json = {
+  '1': 'DrivechainService',
+  '2': [
+    {'1': 'CreateSidechainDeposit', '2': '.bitcoin.drivechaind.v1.CreateSidechainDepositRequest', '3': '.bitcoin.drivechaind.v1.CreateSidechainDepositResponse'},
+  ],
+};
+
+@$core.Deprecated('Use drivechainServiceDescriptor instead')
+const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> DrivechainServiceBase$messageJson = {
+  '.bitcoin.drivechaind.v1.CreateSidechainDepositRequest': CreateSidechainDepositRequest$json,
+  '.bitcoin.drivechaind.v1.CreateSidechainDepositResponse': CreateSidechainDepositResponse$json,
+};
+
+/// Descriptor for `DrivechainService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
+final $typed_data.Uint8List drivechainServiceDescriptor = $convert.base64Decode(
+    'ChFEcml2ZWNoYWluU2VydmljZRKHAQoWQ3JlYXRlU2lkZWNoYWluRGVwb3NpdBI1LmJpdGNvaW'
+    '4uZHJpdmVjaGFpbmQudjEuQ3JlYXRlU2lkZWNoYWluRGVwb3NpdFJlcXVlc3QaNi5iaXRjb2lu'
+    'LmRyaXZlY2hhaW5kLnYxLkNyZWF0ZVNpZGVjaGFpbkRlcG9zaXRSZXNwb25zZQ==');
+

--- a/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbserver.dart
+++ b/packages/faucet/lib/gen/bitcoin/drivechaind/v1/drivechain.pbserver.dart
@@ -1,0 +1,43 @@
+//
+//  Generated code. Do not modify.
+//  source: bitcoin/drivechaind/v1/drivechain.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:async' as $async;
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'drivechain.pb.dart' as $3;
+import 'drivechain.pbjson.dart';
+
+export 'drivechain.pb.dart';
+
+abstract class DrivechainServiceBase extends $pb.GeneratedService {
+  $async.Future<$3.CreateSidechainDepositResponse> createSidechainDeposit($pb.ServerContext ctx, $3.CreateSidechainDepositRequest request);
+
+  $pb.GeneratedMessage createRequest($core.String methodName) {
+    switch (methodName) {
+      case 'CreateSidechainDeposit': return $3.CreateSidechainDepositRequest();
+      default: throw $core.ArgumentError('Unknown method: $methodName');
+    }
+  }
+
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+    switch (methodName) {
+      case 'CreateSidechainDeposit': return this.createSidechainDeposit(ctx, request as $3.CreateSidechainDepositRequest);
+      default: throw $core.ArgumentError('Unknown method: $methodName');
+    }
+  }
+
+  $core.Map<$core.String, $core.dynamic> get $json => DrivechainServiceBase$json;
+  $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> get $messageJson => DrivechainServiceBase$messageJson;
+}
+

--- a/packages/faucet/lib/gen/google/protobuf/timestamp.pb.dart
+++ b/packages/faucet/lib/gen/google/protobuf/timestamp.pb.dart
@@ -1,0 +1,188 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/timestamp.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+import 'package:protobuf/src/protobuf/mixins/well_known.dart' as $mixin;
+
+///  A Timestamp represents a point in time independent of any time zone or local
+///  calendar, encoded as a count of seconds and fractions of seconds at
+///  nanosecond resolution. The count is relative to an epoch at UTC midnight on
+///  January 1, 1970, in the proleptic Gregorian calendar which extends the
+///  Gregorian calendar backwards to year one.
+///
+///  All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+///  second table is needed for interpretation, using a [24-hour linear
+///  smear](https://developers.google.com/time/smear).
+///
+///  The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+///  restricting to that range, we ensure that we can convert to and from [RFC
+///  3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+///
+///  # Examples
+///
+///  Example 1: Compute Timestamp from POSIX `time()`.
+///
+///      Timestamp timestamp;
+///      timestamp.set_seconds(time(NULL));
+///      timestamp.set_nanos(0);
+///
+///  Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+///
+///      struct timeval tv;
+///      gettimeofday(&tv, NULL);
+///
+///      Timestamp timestamp;
+///      timestamp.set_seconds(tv.tv_sec);
+///      timestamp.set_nanos(tv.tv_usec * 1000);
+///
+///  Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+///
+///      FILETIME ft;
+///      GetSystemTimeAsFileTime(&ft);
+///      UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+///
+///      // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+///      // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+///      Timestamp timestamp;
+///      timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+///      timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+///
+///  Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+///
+///      long millis = System.currentTimeMillis();
+///
+///      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+///          .setNanos((int) ((millis % 1000) * 1000000)).build();
+///
+///  Example 5: Compute Timestamp from Java `Instant.now()`.
+///
+///      Instant now = Instant.now();
+///
+///      Timestamp timestamp =
+///          Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+///              .setNanos(now.getNano()).build();
+///
+///  Example 6: Compute Timestamp from current time in Python.
+///
+///      timestamp = Timestamp()
+///      timestamp.GetCurrentTime()
+///
+///  # JSON Mapping
+///
+///  In JSON format, the Timestamp type is encoded as a string in the
+///  [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+///  format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+///  where {year} is always expressed using four digits while {month}, {day},
+///  {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+///  seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+///  are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+///  is required. A proto3 JSON serializer should always use UTC (as indicated by
+///  "Z") when printing the Timestamp type and a proto3 JSON parser should be
+///  able to accept both UTC and other timezones (as indicated by an offset).
+///
+///  For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+///  01:30 UTC on January 15, 2017.
+///
+///  In JavaScript, one can convert a Date object to this format using the
+///  standard
+///  [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+///  method. In Python, a standard `datetime.datetime` object can be converted
+///  to this format using
+///  [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+///  the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+///  the Joda Time's [`ISODateTimeFormat.dateTime()`](
+///  http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
+///  ) to obtain a formatter capable of generating timestamps in this format.
+class Timestamp extends $pb.GeneratedMessage with $mixin.TimestampMixin {
+  factory Timestamp({
+    $fixnum.Int64? seconds,
+    $core.int? nanos,
+  }) {
+    final $result = create();
+    if (seconds != null) {
+      $result.seconds = seconds;
+    }
+    if (nanos != null) {
+      $result.nanos = nanos;
+    }
+    return $result;
+  }
+  Timestamp._() : super();
+  factory Timestamp.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Timestamp.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Timestamp', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.TimestampMixin.toProto3JsonHelper, fromProto3Json: $mixin.TimestampMixin.fromProto3JsonHelper)
+    ..aInt64(1, _omitFieldNames ? '' : 'seconds')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'nanos', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Timestamp clone() => Timestamp()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Timestamp copyWith(void Function(Timestamp) updates) => super.copyWith((message) => updates(message as Timestamp)) as Timestamp;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Timestamp create() => Timestamp._();
+  Timestamp createEmptyInstance() => create();
+  static $pb.PbList<Timestamp> createRepeated() => $pb.PbList<Timestamp>();
+  @$core.pragma('dart2js:noInline')
+  static Timestamp getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Timestamp>(create);
+  static Timestamp? _defaultInstance;
+
+  /// Represents seconds of UTC time since Unix epoch
+  /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+  /// 9999-12-31T23:59:59Z inclusive.
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get seconds => $_getI64(0);
+  @$pb.TagNumber(1)
+  set seconds($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSeconds() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSeconds() => clearField(1);
+
+  /// Non-negative fractions of a second at nanosecond resolution. Negative
+  /// second values with fractions must still have non-negative nanos values
+  /// that count forward in time. Must be from 0 to 999,999,999
+  /// inclusive.
+  @$pb.TagNumber(2)
+  $core.int get nanos => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set nanos($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNanos() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNanos() => clearField(2);
+  /// Creates a new instance from [dateTime].
+  ///
+  /// Time zone information will not be preserved.
+  static Timestamp fromDateTime($core.DateTime dateTime) {
+    final result = create();
+    $mixin.TimestampMixin.setFromDateTime(result, dateTime);
+    return result;
+  }
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/faucet/lib/gen/google/protobuf/timestamp.pbenum.dart
+++ b/packages/faucet/lib/gen/google/protobuf/timestamp.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/timestamp.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/packages/faucet/lib/gen/google/protobuf/timestamp.pbjson.dart
+++ b/packages/faucet/lib/gen/google/protobuf/timestamp.pbjson.dart
@@ -1,0 +1,29 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/timestamp.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use timestampDescriptor instead')
+const Timestamp$json = {
+  '1': 'Timestamp',
+  '2': [
+    {'1': 'seconds', '3': 1, '4': 1, '5': 3, '10': 'seconds'},
+    {'1': 'nanos', '3': 2, '4': 1, '5': 5, '10': 'nanos'},
+  ],
+};
+
+/// Descriptor for `Timestamp`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List timestampDescriptor = $convert.base64Decode(
+    'CglUaW1lc3RhbXASGAoHc2Vjb25kcxgBIAEoA1IHc2Vjb25kcxIUCgVuYW5vcxgCIAEoBVIFbm'
+    'Fub3M=');
+

--- a/packages/faucet/lib/gen/google/protobuf/timestamp.pbserver.dart
+++ b/packages/faucet/lib/gen/google/protobuf/timestamp.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/timestamp.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'timestamp.pb.dart';
+

--- a/packages/faucet/lib/gen/google/protobuf/wrappers.pb.dart
+++ b/packages/faucet/lib/gen/google/protobuf/wrappers.pb.dart
@@ -1,0 +1,506 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/wrappers.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+import 'package:protobuf/src/protobuf/mixins/well_known.dart' as $mixin;
+
+///  Wrapper message for `double`.
+///
+///  The JSON representation for `DoubleValue` is JSON number.
+class DoubleValue extends $pb.GeneratedMessage with $mixin.DoubleValueMixin {
+  factory DoubleValue({
+    $core.double? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  DoubleValue._() : super();
+  factory DoubleValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DoubleValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DoubleValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.DoubleValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.DoubleValueMixin.fromProto3JsonHelper)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OD)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DoubleValue clone() => DoubleValue()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DoubleValue copyWith(void Function(DoubleValue) updates) => super.copyWith((message) => updates(message as DoubleValue)) as DoubleValue;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DoubleValue create() => DoubleValue._();
+  DoubleValue createEmptyInstance() => create();
+  static $pb.PbList<DoubleValue> createRepeated() => $pb.PbList<DoubleValue>();
+  @$core.pragma('dart2js:noInline')
+  static DoubleValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DoubleValue>(create);
+  static DoubleValue? _defaultInstance;
+
+  /// The double value.
+  @$pb.TagNumber(1)
+  $core.double get value => $_getN(0);
+  @$pb.TagNumber(1)
+  set value($core.double v) { $_setDouble(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `float`.
+///
+///  The JSON representation for `FloatValue` is JSON number.
+class FloatValue extends $pb.GeneratedMessage with $mixin.FloatValueMixin {
+  factory FloatValue({
+    $core.double? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  FloatValue._() : super();
+  factory FloatValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FloatValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'FloatValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.FloatValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.FloatValueMixin.fromProto3JsonHelper)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OF)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  FloatValue clone() => FloatValue()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FloatValue copyWith(void Function(FloatValue) updates) => super.copyWith((message) => updates(message as FloatValue)) as FloatValue;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static FloatValue create() => FloatValue._();
+  FloatValue createEmptyInstance() => create();
+  static $pb.PbList<FloatValue> createRepeated() => $pb.PbList<FloatValue>();
+  @$core.pragma('dart2js:noInline')
+  static FloatValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FloatValue>(create);
+  static FloatValue? _defaultInstance;
+
+  /// The float value.
+  @$pb.TagNumber(1)
+  $core.double get value => $_getN(0);
+  @$pb.TagNumber(1)
+  set value($core.double v) { $_setFloat(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `int64`.
+///
+///  The JSON representation for `Int64Value` is JSON string.
+class Int64Value extends $pb.GeneratedMessage with $mixin.Int64ValueMixin {
+  factory Int64Value({
+    $fixnum.Int64? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  Int64Value._() : super();
+  factory Int64Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Int64Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Int64Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.Int64ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.Int64ValueMixin.fromProto3JsonHelper)
+    ..aInt64(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Int64Value clone() => Int64Value()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Int64Value copyWith(void Function(Int64Value) updates) => super.copyWith((message) => updates(message as Int64Value)) as Int64Value;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Int64Value create() => Int64Value._();
+  Int64Value createEmptyInstance() => create();
+  static $pb.PbList<Int64Value> createRepeated() => $pb.PbList<Int64Value>();
+  @$core.pragma('dart2js:noInline')
+  static Int64Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Int64Value>(create);
+  static Int64Value? _defaultInstance;
+
+  /// The int64 value.
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get value => $_getI64(0);
+  @$pb.TagNumber(1)
+  set value($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `uint64`.
+///
+///  The JSON representation for `UInt64Value` is JSON string.
+class UInt64Value extends $pb.GeneratedMessage with $mixin.UInt64ValueMixin {
+  factory UInt64Value({
+    $fixnum.Int64? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  UInt64Value._() : super();
+  factory UInt64Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UInt64Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UInt64Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.UInt64ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.UInt64ValueMixin.fromProto3JsonHelper)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OU6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  UInt64Value clone() => UInt64Value()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UInt64Value copyWith(void Function(UInt64Value) updates) => super.copyWith((message) => updates(message as UInt64Value)) as UInt64Value;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UInt64Value create() => UInt64Value._();
+  UInt64Value createEmptyInstance() => create();
+  static $pb.PbList<UInt64Value> createRepeated() => $pb.PbList<UInt64Value>();
+  @$core.pragma('dart2js:noInline')
+  static UInt64Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UInt64Value>(create);
+  static UInt64Value? _defaultInstance;
+
+  /// The uint64 value.
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get value => $_getI64(0);
+  @$pb.TagNumber(1)
+  set value($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `int32`.
+///
+///  The JSON representation for `Int32Value` is JSON number.
+class Int32Value extends $pb.GeneratedMessage with $mixin.Int32ValueMixin {
+  factory Int32Value({
+    $core.int? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  Int32Value._() : super();
+  factory Int32Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Int32Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Int32Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.Int32ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.Int32ValueMixin.fromProto3JsonHelper)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Int32Value clone() => Int32Value()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Int32Value copyWith(void Function(Int32Value) updates) => super.copyWith((message) => updates(message as Int32Value)) as Int32Value;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Int32Value create() => Int32Value._();
+  Int32Value createEmptyInstance() => create();
+  static $pb.PbList<Int32Value> createRepeated() => $pb.PbList<Int32Value>();
+  @$core.pragma('dart2js:noInline')
+  static Int32Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Int32Value>(create);
+  static Int32Value? _defaultInstance;
+
+  /// The int32 value.
+  @$pb.TagNumber(1)
+  $core.int get value => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set value($core.int v) { $_setSignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `uint32`.
+///
+///  The JSON representation for `UInt32Value` is JSON number.
+class UInt32Value extends $pb.GeneratedMessage with $mixin.UInt32ValueMixin {
+  factory UInt32Value({
+    $core.int? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  UInt32Value._() : super();
+  factory UInt32Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UInt32Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UInt32Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.UInt32ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.UInt32ValueMixin.fromProto3JsonHelper)
+    ..a<$core.int>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  UInt32Value clone() => UInt32Value()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UInt32Value copyWith(void Function(UInt32Value) updates) => super.copyWith((message) => updates(message as UInt32Value)) as UInt32Value;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UInt32Value create() => UInt32Value._();
+  UInt32Value createEmptyInstance() => create();
+  static $pb.PbList<UInt32Value> createRepeated() => $pb.PbList<UInt32Value>();
+  @$core.pragma('dart2js:noInline')
+  static UInt32Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UInt32Value>(create);
+  static UInt32Value? _defaultInstance;
+
+  /// The uint32 value.
+  @$pb.TagNumber(1)
+  $core.int get value => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set value($core.int v) { $_setUnsignedInt32(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `bool`.
+///
+///  The JSON representation for `BoolValue` is JSON `true` and `false`.
+class BoolValue extends $pb.GeneratedMessage with $mixin.BoolValueMixin {
+  factory BoolValue({
+    $core.bool? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  BoolValue._() : super();
+  factory BoolValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BoolValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BoolValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.BoolValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.BoolValueMixin.fromProto3JsonHelper)
+    ..aOB(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BoolValue clone() => BoolValue()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BoolValue copyWith(void Function(BoolValue) updates) => super.copyWith((message) => updates(message as BoolValue)) as BoolValue;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BoolValue create() => BoolValue._();
+  BoolValue createEmptyInstance() => create();
+  static $pb.PbList<BoolValue> createRepeated() => $pb.PbList<BoolValue>();
+  @$core.pragma('dart2js:noInline')
+  static BoolValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BoolValue>(create);
+  static BoolValue? _defaultInstance;
+
+  /// The bool value.
+  @$pb.TagNumber(1)
+  $core.bool get value => $_getBF(0);
+  @$pb.TagNumber(1)
+  set value($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `string`.
+///
+///  The JSON representation for `StringValue` is JSON string.
+class StringValue extends $pb.GeneratedMessage with $mixin.StringValueMixin {
+  factory StringValue({
+    $core.String? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  StringValue._() : super();
+  factory StringValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory StringValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StringValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.StringValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.StringValueMixin.fromProto3JsonHelper)
+    ..aOS(1, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  StringValue clone() => StringValue()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  StringValue copyWith(void Function(StringValue) updates) => super.copyWith((message) => updates(message as StringValue)) as StringValue;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StringValue create() => StringValue._();
+  StringValue createEmptyInstance() => create();
+  static $pb.PbList<StringValue> createRepeated() => $pb.PbList<StringValue>();
+  @$core.pragma('dart2js:noInline')
+  static StringValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StringValue>(create);
+  static StringValue? _defaultInstance;
+
+  /// The string value.
+  @$pb.TagNumber(1)
+  $core.String get value => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set value($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+///  Wrapper message for `bytes`.
+///
+///  The JSON representation for `BytesValue` is JSON string.
+class BytesValue extends $pb.GeneratedMessage with $mixin.BytesValueMixin {
+  factory BytesValue({
+    $core.List<$core.int>? value,
+  }) {
+    final $result = create();
+    if (value != null) {
+      $result.value = value;
+    }
+    return $result;
+  }
+  BytesValue._() : super();
+  factory BytesValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BytesValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'BytesValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.BytesValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.BytesValueMixin.fromProto3JsonHelper)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'value', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  BytesValue clone() => BytesValue()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BytesValue copyWith(void Function(BytesValue) updates) => super.copyWith((message) => updates(message as BytesValue)) as BytesValue;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static BytesValue create() => BytesValue._();
+  BytesValue createEmptyInstance() => create();
+  static $pb.PbList<BytesValue> createRepeated() => $pb.PbList<BytesValue>();
+  @$core.pragma('dart2js:noInline')
+  static BytesValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BytesValue>(create);
+  static BytesValue? _defaultInstance;
+
+  /// The bytes value.
+  @$pb.TagNumber(1)
+  $core.List<$core.int> get value => $_getN(0);
+  @$pb.TagNumber(1)
+  set value($core.List<$core.int> v) { $_setBytes(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearValue() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/faucet/lib/gen/google/protobuf/wrappers.pbenum.dart
+++ b/packages/faucet/lib/gen/google/protobuf/wrappers.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/wrappers.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/packages/faucet/lib/gen/google/protobuf/wrappers.pbjson.dart
+++ b/packages/faucet/lib/gen/google/protobuf/wrappers.pbjson.dart
@@ -1,0 +1,123 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/wrappers.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use doubleValueDescriptor instead')
+const DoubleValue$json = {
+  '1': 'DoubleValue',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 1, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `DoubleValue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List doubleValueDescriptor = $convert.base64Decode(
+    'CgtEb3VibGVWYWx1ZRIUCgV2YWx1ZRgBIAEoAVIFdmFsdWU=');
+
+@$core.Deprecated('Use floatValueDescriptor instead')
+const FloatValue$json = {
+  '1': 'FloatValue',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 2, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `FloatValue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List floatValueDescriptor = $convert.base64Decode(
+    'CgpGbG9hdFZhbHVlEhQKBXZhbHVlGAEgASgCUgV2YWx1ZQ==');
+
+@$core.Deprecated('Use int64ValueDescriptor instead')
+const Int64Value$json = {
+  '1': 'Int64Value',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 3, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `Int64Value`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List int64ValueDescriptor = $convert.base64Decode(
+    'CgpJbnQ2NFZhbHVlEhQKBXZhbHVlGAEgASgDUgV2YWx1ZQ==');
+
+@$core.Deprecated('Use uInt64ValueDescriptor instead')
+const UInt64Value$json = {
+  '1': 'UInt64Value',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 4, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `UInt64Value`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List uInt64ValueDescriptor = $convert.base64Decode(
+    'CgtVSW50NjRWYWx1ZRIUCgV2YWx1ZRgBIAEoBFIFdmFsdWU=');
+
+@$core.Deprecated('Use int32ValueDescriptor instead')
+const Int32Value$json = {
+  '1': 'Int32Value',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 5, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `Int32Value`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List int32ValueDescriptor = $convert.base64Decode(
+    'CgpJbnQzMlZhbHVlEhQKBXZhbHVlGAEgASgFUgV2YWx1ZQ==');
+
+@$core.Deprecated('Use uInt32ValueDescriptor instead')
+const UInt32Value$json = {
+  '1': 'UInt32Value',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 13, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `UInt32Value`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List uInt32ValueDescriptor = $convert.base64Decode(
+    'CgtVSW50MzJWYWx1ZRIUCgV2YWx1ZRgBIAEoDVIFdmFsdWU=');
+
+@$core.Deprecated('Use boolValueDescriptor instead')
+const BoolValue$json = {
+  '1': 'BoolValue',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 8, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `BoolValue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List boolValueDescriptor = $convert.base64Decode(
+    'CglCb29sVmFsdWUSFAoFdmFsdWUYASABKAhSBXZhbHVl');
+
+@$core.Deprecated('Use stringValueDescriptor instead')
+const StringValue$json = {
+  '1': 'StringValue',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `StringValue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List stringValueDescriptor = $convert.base64Decode(
+    'CgtTdHJpbmdWYWx1ZRIUCgV2YWx1ZRgBIAEoCVIFdmFsdWU=');
+
+@$core.Deprecated('Use bytesValueDescriptor instead')
+const BytesValue$json = {
+  '1': 'BytesValue',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 12, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `BytesValue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bytesValueDescriptor = $convert.base64Decode(
+    'CgpCeXRlc1ZhbHVlEhQKBXZhbHVlGAEgASgMUgV2YWx1ZQ==');
+

--- a/packages/faucet/lib/gen/google/protobuf/wrappers.pbserver.dart
+++ b/packages/faucet/lib/gen/google/protobuf/wrappers.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/wrappers.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'wrappers.pb.dart';
+

--- a/packages/faucet/lib/providers/transactions_provider.dart
+++ b/packages/faucet/lib/providers/transactions_provider.dart
@@ -1,15 +1,15 @@
 import 'dart:async';
 
+import 'package:faucet/gen/bitcoin/bitcoind/v1alpha/bitcoin.pb.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
-import 'package:sail_ui/sail_ui.dart';
 
 import '../../api/api.dart';
 
 class TransactionsProvider extends ChangeNotifier {
   API get api => GetIt.I.get<API>();
 
-  List<UTXO> claims = [];
+  List<GetTransactionResponse> claims = [];
   bool initialized = false;
 
   bool _isFetching = false;
@@ -41,7 +41,7 @@ class TransactionsProvider extends ChangeNotifier {
   }
 
   bool _dataHasChanged(
-    List<UTXO> newClaims,
+    List<GetTransactionResponse> newClaims,
     bool newInitialized,
   ) {
     if (newInitialized != initialized) {

--- a/packages/faucet/pubspec.lock
+++ b/packages/faucet/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: auto_route
-      sha256: "901050372696c7fddb5b698ea328088366c13e133f9eac456cfca250b7b3c37c"
+      sha256: b83e8ce46da7228cdd019b5a11205454847f0a971bca59a7529b98df9876889b
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.1+1"
+    version: "9.2.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  fixnum:
+    dependency: "direct main"
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -184,6 +192,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.7.0"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5be191523702ba8d7a01ca97c17fca096822ccf246b0a9f11923a6ded06199b6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1+4"
+  googleapis_auth:
+    dependency: transitive
+    description:
+      name: googleapis_auth
+      sha256: befd71383a955535060acde8792e7efc11d2fccd03dd1d3ec434e85b68775938
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  grpc:
+    dependency: "direct main"
+    description:
+      name: grpc
+      sha256: "5b99b7a420937d4361ece68b798c9af8e04b5bc128a7859f2a4be87427694813"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   http:
     dependency: "direct main"
     description:
@@ -192,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  http2:
+    dependency: transitive
+    description:
+      name: http2
+      sha256: "9ced024a160b77aba8fb8674e38f70875e321d319e6f303ec18e87bd5a4b0c1d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   http_parser:
     dependency: transitive
     description:
@@ -316,10 +356,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -332,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -344,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  protobuf:
+    dependency: "direct main"
+    description:
+      name: protobuf
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   provider:
     dependency: transitive
     description:
@@ -371,10 +419,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a7e8467e9181cef109f601e3f65765685786c1a738a83d7fbbde377589c0d974
+      sha256: "480ba4345773f56acda9abf5f50bd966f581dac5d514e5fc4a18c62976bbba7e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -440,18 +488,18 @@ packages:
     dependency: "direct main"
     description:
       name: stacked
-      sha256: "32641025f7bedf3acddd068008932c5f4d89bd089f1b091f61c9fe466c66229e"
+      sha256: ed19ecdc2dcc682b9be9c7e34646e603c0f770437a914b15c7d2d13391c92a09
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.4.3"
   stacked_shared:
     dependency: transitive
     description:
       name: stacked_shared
-      sha256: e6bc2921eb59b7c741c551fbb4060f22a543ea9c2d9351315fb58aa055b535f3
+      sha256: "26e11dcfe23df81d565d0180eb5bcf4742efed066ba3328623b458f21a82b346"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   stream_channel:
     dependency: transitive
     description:
@@ -552,10 +600,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:
@@ -564,14 +612,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/faucet/pubspec.yaml
+++ b/packages/faucet/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   sail_ui:
     path: ../sail_ui
 
+  grpc: ^4.0.0
+  fixnum: ^1.1.0
   cupertino_icons: ^1.0.8
   stacked: ^3.4.2
   get_it: ^7.7.0
@@ -21,6 +23,7 @@ dependencies:
   http: ^1.2.1
   intl: ^0.19.0
   shared_preferences: ^2.2.3
+  protobuf: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
now that the backend uses btcbuf, the frontend should as well. This adds a buf.yaml file for generating types.