### PR TITLE
ci: only run when changes are made to relevant dir

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,6 +1,13 @@
 name: Dart
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'packages/sail_ui/**'
+      - 'packages/sidesail/**'
+      - 'packages/drivechain_client/**'
+      - 'packages/faucet_client/**'
+      - '.github/workflows/**'
 
 jobs:
   format-lint-test:

--- a/.github/workflows/drivechain-server.yml
+++ b/.github/workflows/drivechain-server.yml
@@ -3,6 +3,9 @@ name: Drivechain server
 on:
   pull_request:
     branches: [master]
+    paths:
+      - 'drivechain-server/**'
+      - '.github/workflows/**'
 
 defaults:
   run:

--- a/.github/workflows/faucet-backend.yml
+++ b/.github/workflows/faucet-backend.yml
@@ -3,6 +3,9 @@ name: Faucet backend
 on:
   pull_request:
     branches: [master]
+    paths:
+      - 'faucet-backend/**'
+      - '.github/workflows/**'
 
 defaults:
   run:

--- a/.github/workflows/sidesail.yml
+++ b/.github/workflows/sidesail.yml
@@ -3,8 +3,13 @@ name: Sidesail
 on:
   push:
     branches: ["master"]
+    paths:
+      - 'packages/sidesail/**'
   pull_request:
     branches: ["master"]
+    paths:
+      - 'packages/sidesail/**'
+      - '.github/workflows/**'
 
 defaults:
   run:


### PR DESCRIPTION
if only faucet_client is changed, only run CI for faucet_client etc.

It feels rather not elegant to include the workflows-repo, but it works wonders