### PR TITLE
drivechain_client: add transaction fee section, lift state

### DIFF
--- a/packages/drivechain_client/lib/pages/send_page.dart
+++ b/packages/drivechain_client/lib/pages/send_page.dart
@@ -17,108 +17,115 @@ class SendPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return QtPage(
-      child: ViewModelBuilder<SendPageViewModel>.reactive(
-        viewModelBuilder: () => SendPageViewModel(),
-        onViewModelReady: (model) => model.init(),
-        builder: (context, model, child) {
-          return Column(
-            mainAxisSize: MainAxisSize.max,
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                    left: 12.0,
-                    right: 12.0,
-                    top: 12.0,
-                    bottom: 4.0,
-                  ),
-                  child: QtContainer(
-                    child: SendDetailsForm(model: model),
-                  ),
-                ),
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                    left: 12.0,
-                    right: 12.0,
-                    top: 12.0,
-                    bottom: 4.0,
-                  ),
-                  child: QtContainer(
-                    child: TransactionFeeForm(model: model),
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12.0,
-                  vertical: 16.0,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
+    return Column(
+      children: [
+        Expanded(
+          child: QtPage(
+            child: ViewModelBuilder<SendPageViewModel>.reactive(
+              viewModelBuilder: () => SendPageViewModel(),
+              onViewModelReady: (model) => model.init(),
+              builder: (context, model, child) {
+                return Column(
+                  mainAxisSize: MainAxisSize.max,
                   children: [
-                    const Row(),
-                    // Balance
-                    FutureBuilder(
-                      future: api.getBalance(),
-                      builder: (context, snapshot) {
-                        if (snapshot.hasData) {
-                          final balance = Money.fromNumWithCurrency(
-                            snapshot.data!.confirmedSatoshi.toDouble() +
-                                snapshot.data!.pendingSatoshi.toDouble(),
-                            satoshi,
-                          ).toString();
-                          return SailText.primary12('Balance: $balance');
-                        } else if (snapshot.hasError) {
-                          return SailText.primary12('Error: ${snapshot.error}');
-                        } else {
-                          return SailText.primary12('Balance: Loading...');
-                        }
-                      },
+                    Expanded(
+                      child: QtContainer(
+                        child: SendDetailsForm(model: model),
+                      ),
+                    ),
+                    const SizedBox(height: SailStyleValues.padding08),
+                    Expanded(
+                      child: QtContainer(
+                        child: TransactionFeeForm(model: model),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(
+                        top: SailStyleValues.padding08,
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              QtButton(
+                                onPressed: model.sendTransaction,
+                                child: SailText.primary12('Send'),
+                              ),
+                              const SizedBox(width: SailStyleValues.padding08),
+                              QtButton(
+                                onPressed: model.clearAll,
+                                child: SailText.primary12('Clear All'),
+                              ),
+                              const SizedBox(width: SailStyleValues.padding08),
+                              QtButton(
+                                onPressed: model.addRecipient,
+                                child: SailText.primary12('Add Recipient'),
+                              ),
+                            ],
+                          ),
+                          // Balance
+                          FutureBuilder(
+                            future: api.getBalance(),
+                            builder: (context, snapshot) {
+                              if (snapshot.hasData) {
+                                final balance = Money.fromNumWithCurrency(
+                                  snapshot.data!.confirmedSatoshi.toDouble() + snapshot.data!.pendingSatoshi.toDouble(),
+                                  satoshi,
+                                ).toString();
+                                return SailText.primary12('Balance: $balance');
+                              } else if (snapshot.hasError) {
+                                return SailText.primary12('Error: ${snapshot.error}');
+                              } else {
+                                return SailText.primary12('Balance: Loading...');
+                              }
+                            },
+                          ),
+                        ],
+                      ),
                     ),
                   ],
-                ),
+                );
+              },
+            ),
+          ),
+        ),
+        DecoratedBox(
+          decoration: const BoxDecoration(
+            border: Border(
+              top: BorderSide(
+                color: Colors.grey,
               ),
-              DecoratedBox(
-                decoration: const BoxDecoration(
-                  border: Border(
-                    top: BorderSide(
-                      color: Colors.grey,
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            // Add a left border to every child
+            children: [
+              // TODO: Get actual info from the node
+              SailText.primary12('195755 blocks'),
+              SailText.primary12('1 peer'),
+              SailText.primary12('Last block: 6 days ago'),
+            ]
+                .map(
+                  (child) => Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4.0,
+                      vertical: 2.0,
                     ),
+                    decoration: const BoxDecoration(
+                      border: Border(
+                        left: BorderSide(color: Colors.grey),
+                      ),
+                    ),
+                    child: child,
                   ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  // Add a left border to every child
-                  children: [
-                    // TODO: Get actual info from the node
-                    SailText.primary12('195755 blocks'),
-                    SailText.primary12('1 peer'),
-                    SailText.primary12('Last block: 6 days ago'),
-                  ]
-                      .map(
-                        (child) => Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 4.0,
-                            vertical: 2.0,
-                          ),
-                          decoration: const BoxDecoration(
-                            border: Border(
-                              left: BorderSide(color: Colors.grey),
-                            ),
-                          ),
-                          child: child,
-                        ),
-                      )
-                      .toList(),
-                ),
-              ),
-            ],
-          );
-        },
-      ),
+                )
+                .toList(),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -149,8 +156,7 @@ class SendDetailsForm extends StatelessWidget {
             Expanded(
               child: SailTextField(
                 controller: model.addressController,
-                hintText:
-                    'Enter a Drivechain address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)',
+                hintText: 'Enter a Drivechain address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)',
                 size: TextFieldSize.small,
               ),
             ),
@@ -171,8 +177,7 @@ class SendDetailsForm extends StatelessWidget {
                   await SystemClipboard.instance?.read().then((reader) async {
                     if (reader.canProvide(Formats.plainText)) {
                       final text = await reader.readValue(Formats.plainText);
-                      model.addressController.text =
-                          text ?? model.addressController.text;
+                      model.addressController.text = text ?? model.addressController.text;
                     }
                   });
                 } else {
@@ -210,8 +215,7 @@ class SendDetailsForm extends StatelessWidget {
             Expanded(
               child: SailTextField(
                 controller: model.labelController,
-                hintText:
-                    'Enter a label for this address to add it to your address book',
+                hintText: 'Enter a label for this address to add it to your address book',
                 size: TextFieldSize.small,
               ),
             ),
@@ -260,24 +264,10 @@ class SendDetailsForm extends StatelessWidget {
                   ),
                   QtButton(
                     onPressed: model.onUseAvailableBalance,
-                    child: const Text('Use available balance'),
+                    child: SailText.primary12('Use available balance'),
                   ),
                 ],
               ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16.0),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            QtButton(
-              onPressed: model.clearAll,
-              child: const Text('Clear All'),
-            ),
-            QtButton(
-              onPressed: model.sendTransaction,
-              child: const Text('Send'),
             ),
           ],
         ),
@@ -296,9 +286,19 @@ class TransactionFeeForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SailText.primary12(
-          'Transaction Fee:',
-          bold: true,
+        Row(
+          children: [
+            SailText.primary12(
+              'Transaction Fee:',
+              bold: true,
+            ),
+            const SizedBox(width: SailStyleValues.padding08),
+            SailText.primary12(
+              'Warning: Fee estimation is currently not possible.',
+              bold: true,
+              color: context.sailTheme.colors.primary,
+            ),
+          ],
         ),
         const SizedBox(height: 16.0),
         Row(
@@ -326,7 +326,7 @@ class TransactionFeeForm extends StatelessWidget {
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8.0),
+                    const SizedBox(height: SailStyleValues.padding08),
                     Row(
                       children: [
                         SailText.primary12('Confirmation time target:'),
@@ -338,11 +338,11 @@ class TransactionFeeForm extends StatelessWidget {
                             return SailDropdownItem(
                               value: target,
                               child: SailText.primary12(
-                                  model.getConfirmationTargetLabel(target)),
+                                model.getConfirmationTargetLabel(target),
+                              ),
                             );
                           }).toList(),
-                          onChanged: (value) =>
-                              model.setConfirmationTarget(value),
+                          onChanged: (value) => model.setConfirmationTarget(value),
                           value: model.confirmationTarget,
                         ),
                       ],
@@ -374,30 +374,28 @@ class TransactionFeeForm extends StatelessWidget {
                       Row(
                         children: [
                           SailText.primary12('Per kB:'),
-                          const SizedBox(width: 8.0),
+                          const SizedBox(width: SailStyleValues.padding08),
                           Expanded(
                             flex: 2,
                             child: NumericField(
                               controller: model.customFeeController,
                               hintText: 'Custom fee',
-                              enabled: model.feeType == 'custom' &&
-                                  !model.useMinimumFee,
+                              enabled: model.feeType == 'custom' && !model.useMinimumFee,
                             ),
                           ),
-                          const SizedBox(width: 8.0),
+                          const SizedBox(width: SailStyleValues.padding08),
                           Expanded(
                             flex: 1,
                             child: UnitDropdown(
                               value: model.feeUnit,
                               onChanged: model.onFeeUnitChanged,
-                              enabled: model.feeType == 'custom' &&
-                                  !model.useMinimumFee,
+                              enabled: model.feeType == 'custom' && !model.useMinimumFee,
                             ),
                           ),
                           const SizedBox(width: 16.0),
                         ],
                       ),
-                      const SizedBox(height: 8.0),
+                      const SizedBox(height: SailStyleValues.padding08),
                       Row(
                         children: [
                           Tooltip(
@@ -412,13 +410,9 @@ Drivechain transactions than the
 network can process.''',
                             child: SailCheckbox(
                               value: model.useMinimumFee,
-                              onChanged: model.feeType == 'custom'
-                                  ? model.setUseMinimumFee
-                                  : null,
-                              label:
-                                  'Pay only the require fee of 10.00 bits/kB (read the tooltip)',
-                              enabled: model.feeType == 'custom' &&
-                                  !model.useMinimumFee,
+                              onChanged: model.feeType == 'custom' ? model.setUseMinimumFee : null,
+                              label: 'Pay only the required fee of 10.00 bits/kB (read the tooltip)',
+                              enabled: model.feeType == 'custom' && !model.useMinimumFee,
                             ),
                           ),
                         ],
@@ -548,9 +542,7 @@ class _NumericFieldState extends State<NumericField> {
       size: TextFieldSize.small,
       dense: true,
       enabled: widget.enabled,
-      onSubmitted: widget.onSubmitted != null
-          ? (value) => widget.onSubmitted!(value)
-          : null,
+      onSubmitted: widget.onSubmitted != null ? (value) => widget.onSubmitted!(value) : null,
     );
   }
 }
@@ -631,8 +623,8 @@ class QtButton extends StatelessWidget {
     required this.onPressed,
     required this.child,
     this.padding = const EdgeInsets.symmetric(
-      horizontal: SailStyleValues.padding15,
-      vertical: 0.0,
+      horizontal: SailStyleValues.padding30,
+      vertical: SailStyleValues.padding10,
     ),
     this.large = false,
     this.important = false,
@@ -641,15 +633,29 @@ class QtButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: large ? 32 : 24,
-      child: SailRawButton(
-        disabled: !enabled,
-        loading: false,
-        onPressed: enabled ? onPressed : null,
-        padding: padding,
-        child: child,
+    final color = enabled ? context.sailTheme.colors.background : context.sailTheme.colors.disabledBackground;
+    return RawMaterialButton(
+      mouseCursor: enabled ? WidgetStateMouseCursor.clickable : SystemMouseCursors.forbidden,
+      fillColor: color,
+      elevation: 0.0,
+      focusElevation: 0.0,
+      hoverElevation: 0.0,
+      hoverColor: color,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(6.0),
+        side: BorderSide(
+          color: context.sailTheme.colors.formFieldBorder,
+          width: 0.5,
+        ),
       ),
+      visualDensity: VisualDensity.compact,
+      constraints: const BoxConstraints(
+        minWidth: 24,
+        minHeight: 24,
+      ),
+      onPressed: enabled ? onPressed : null,
+      padding: padding,
+      child: child,
     );
   }
 }
@@ -788,8 +794,10 @@ class SendPageViewModel extends BaseViewModel {
   }
 
   void sendTransaction() {
-    // Implement the logic to send the transaction
-    // This should use the values from all form fields, including the new fee-related fields
-    // You'll need to integrate this with your DrivechainService
+    // TODO: Implement the logic to send the transaction
+  }
+
+  void addRecipient() {
+    // TODO: Implement the logic to add a recipient
   }
 }

--- a/packages/drivechain_client/pubspec.yaml
+++ b/packages/drivechain_client/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   dotted_border: ^2.1.0
   money2: ^5.2.1
   super_clipboard: ^0.8.21
-  stacked: ^3.4.3
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/drivechain_client/pubspec.yaml
+++ b/packages/drivechain_client/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   dotted_border: ^2.1.0
   money2: ^5.2.1
   super_clipboard: ^0.8.21
+  stacked: ^3.4.3
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/sail_ui/lib/sail_ui.dart
+++ b/packages/sail_ui/lib/sail_ui.dart
@@ -40,6 +40,7 @@ export './widgets/inputs/dropdown_menu.dart';
 export './widgets/inputs/checkbox.dart';
 export './widgets/inputs/menu.dart';
 export './widgets/inputs/menu_items.dart';
+export './widgets/inputs/radio_button.dart';
 export './widgets/nav/nav_components.dart';
 export './widgets/spacing.dart';
 export './widgets/static/static_field.dart';

--- a/packages/sail_ui/lib/style/color.dart
+++ b/packages/sail_ui/lib/style/color.dart
@@ -22,6 +22,7 @@ class SailColor {
   final Color success;
   final Color info;
   final Color yellow;
+  final Color disabledBackground;
 
   final Color actionHeader;
   final Color chip;
@@ -48,6 +49,7 @@ class SailColor {
     required this.yellow,
     required this.actionHeader,
     required this.chip,
+    required this.disabledBackground,
   });
 
   factory SailColor.lightTheme(Color primary) {
@@ -73,6 +75,7 @@ class SailColor {
       actionHeader: SailColorScheme.whiteDark,
       chip: SailColorScheme.greyMiddle.withOpacity(0.21),
       popoverBackground: SailColorScheme.white,
+      disabledBackground: SailColorScheme.greyLight.withOpacity(0.1),
     );
   }
   factory SailColor.darkTheme(Color primary) {
@@ -98,6 +101,7 @@ class SailColor {
       yellow: SailColorScheme.yellow,
       chip: SailColorScheme.darkChip,
       popoverBackground: SailColorScheme.darkBackground,
+      disabledBackground: SailColorScheme.whiteDark,
     );
   }
 }

--- a/packages/sail_ui/lib/widgets/buttons/button.dart
+++ b/packages/sail_ui/lib/widgets/buttons/button.dart
@@ -198,6 +198,7 @@ class _SailRawButtonState extends State<SailRawButton> with SingleTickerProvider
     }
 
     return MaterialButton(
+      mouseCursor: disabled ? SystemMouseCursors.forbidden : WidgetStateMouseCursor.clickable,
       visualDensity: theme.dense ? VisualDensity.compact : null,
       onPressed: disabled ? null : widget.onPressed,
       disabledColor: backgroundColor,

--- a/packages/sail_ui/lib/widgets/inputs/checkbox.dart
+++ b/packages/sail_ui/lib/widgets/inputs/checkbox.dart
@@ -38,7 +38,7 @@ class _SailCheckboxState extends State<SailCheckbox> {
         color = context.sailTheme.colors.primary;
         if (_pressed) color = Color.lerp(color, Colors.black, 0.2)!;
       } else {
-        color = context.sailTheme.colors.backgroundSecondary;
+        color = context.sailTheme.colors.disabledBackground;
       }
 
       visual = Container(
@@ -83,38 +83,44 @@ class _SailCheckboxState extends State<SailCheckbox> {
             padding: const EdgeInsets.only(left: 8.0),
             child: SailText.primary12(
               widget.label!,
-              color: enabled
-                    ? context.sailTheme.colors.text
-                    : context.sailTheme.colors.textSecondary,
+              color: enabled ? context.sailTheme.colors.text : context.sailTheme.colors.textSecondary,
             ),
           ),
         ],
       );
     }
 
-    if (!enabled) return visual;
-
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: () {
-        widget.onChanged!(!widget.value);
-      },
-      onTapDown: (_) {
-        setState(() {
-          _pressed = true;
-        });
-      },
-      onTapCancel: () {
-        setState(() {
-          _pressed = false;
-        });
-      },
-      onTapUp: (_) {
-        setState(() {
-          _pressed = false;
-        });
-      },
-      child: visual,
+    return MouseRegion(
+      cursor: enabled ? WidgetStateMouseCursor.clickable : SystemMouseCursors.forbidden,
+      child: Builder(
+        builder: (context) {
+          if (!enabled) {
+            return visual;
+          }
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {
+              widget.onChanged!(!widget.value);
+            },
+            onTapDown: (_) {
+              setState(() {
+                _pressed = true;
+              });
+            },
+            onTapCancel: () {
+              setState(() {
+                _pressed = false;
+              });
+            },
+            onTapUp: (_) {
+              setState(() {
+                _pressed = false;
+              });
+            },
+            child: visual,
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/sail_ui/lib/widgets/inputs/dropdown_menu.dart
+++ b/packages/sail_ui/lib/widgets/inputs/dropdown_menu.dart
@@ -12,6 +12,7 @@ class SailDropdownButton<T> extends StatefulWidget {
     ),
     this.width,
     this.large = false,
+    this.enabled = true,
     super.key,
   });
 
@@ -21,7 +22,7 @@ class SailDropdownButton<T> extends StatefulWidget {
   final Widget? icon;
   final double? width;
   final bool large;
-
+  final bool enabled;
   @override
   State<StatefulWidget> createState() => _SailDropdownButtonState<T>();
 }
@@ -59,25 +60,28 @@ class _SailDropdownButtonState<T> extends State<SailDropdownButton<T>> {
       width: widget.width,
       height: widget.large ? 32 : 24,
       child: _Button(
+        enabled: widget.enabled,
         large: widget.large,
         padding: EdgeInsets.only(
           left: 8,
           right: widget.icon == null ? 8 : 4,
         ),
-        onPressed: () {
-          var bounds = getGlobalBoundsForContext(context);
-          showSailMenu(
-            context: context,
-            preferredAnchorPoint: Offset(
-              bounds.left - (context.isWindows ? 1 : 9),
-              bounds.top - offsetY - 3,
-            ),
-            menu: SailMenu(
-              items: items,
-              width: widget.width,
-            ),
-          );
-        },
+        onPressed: widget.enabled
+            ? () {
+                var bounds = getGlobalBoundsForContext(context);
+                showSailMenu(
+                  context: context,
+                  preferredAnchorPoint: Offset(
+                    bounds.left - (context.isWindows ? 1 : 9),
+                    bounds.top - offsetY - 3,
+                  ),
+                  menu: SailMenu(
+                    items: items,
+                    width: widget.width,
+                  ),
+                );
+              }
+            : null,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           mainAxisSize: MainAxisSize.max,
@@ -119,7 +123,7 @@ class _Button extends StatelessWidget {
   final Widget child;
   final EdgeInsets padding;
   final bool large;
-
+  final bool enabled;
   const _Button({
     required this.onPressed,
     required this.child,
@@ -128,13 +132,14 @@ class _Button extends StatelessWidget {
       vertical: 0,
     ),
     required this.large,
+    this.enabled = true,
   });
 
   @override
   Widget build(BuildContext context) {
     Color textColor;
     final sailTheme = context.sailTheme;
-    if (onPressed != null) {
+    if (onPressed != null && enabled) {
       textColor = sailTheme.colors.text;
     } else {
       textColor = sailTheme.colors.textTertiary;
@@ -144,12 +149,13 @@ class _Button extends StatelessWidget {
       height: large ? 32 : 24,
       child: MaterialButton(
         // textTheme: textTheme,
-        color: sailTheme.colors.background,
+        mouseCursor: enabled ? WidgetStateMouseCursor.clickable : SystemMouseCursors.forbidden,
+        color: enabled ? sailTheme.colors.background : sailTheme.colors.disabledBackground,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(context.isWindows ? 3 : 4)),
           side: BorderSide(
-            color: sailTheme.colors.divider,
-            width: 0.5,
+            color: sailTheme.colors.formFieldBorder,
+            width: 1,
           ),
         ),
         onPressed: onPressed,

--- a/packages/sail_ui/lib/widgets/inputs/radio_button.dart
+++ b/packages/sail_ui/lib/widgets/inputs/radio_button.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+class SailRadioButton<T> extends StatefulWidget {
+  final T value;
+  final T groupValue;
+  final ValueChanged<T>? onChanged;
+  final String? label;
+  final double size;
+  final bool enabled;
+
+  const SailRadioButton({
+    required this.value,
+    required this.groupValue,
+    this.onChanged,
+    this.label,
+    this.size = 16.0,
+    this.enabled = true,
+    super.key,
+  });
+
+  @override
+  State<SailRadioButton<T>> createState() => _SailRadioButtonState<T>();
+}
+
+class _SailRadioButtonState<T> extends State<SailRadioButton<T>> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    var enabled = widget.onChanged != null && widget.enabled;
+
+    Widget visual;
+    if (widget.value == widget.groupValue) {
+      Color color;
+
+      if (enabled) {
+        color = SailTheme.of(context).colors.primary;
+        if (_pressed) color = Color.lerp(color, Colors.black, 0.2)!;
+      } else {
+        color = Theme.of(context).disabledColor;
+      }
+
+      visual = Container(
+        width: widget.size,
+        height: widget.size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          // borderRadius: BorderRadius.all(Radius.circular(widget.cornerRadius)),
+          color: color,
+          boxShadow: enabled ? sailBoxShadow(context) : null,
+        ),
+        child: Icon(
+          Icons.circle,
+          size: widget.size / 2,
+          color: SailTheme.of(context).colors.background,
+        ),
+      );
+    } else {
+      var color = SailTheme.of(context).colors.background;
+      if (_pressed) color = Color.lerp(color, Colors.black, 0.2)!;
+
+      visual = Container(
+        width: widget.size,
+        height: widget.size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          // borderRadius: BorderRadius.all(Radius.circular(widget.cornerRadius)),
+          color: color,
+          border: Border.all(color: SailTheme.of(context).colors.formFieldBorder, width: 1.0),
+          boxShadow: sailBoxShadow(context),
+        ),
+      );
+    }
+
+    if (widget.label != null) {
+      var textStyle = SailStyleValues.twelve;
+      if (!enabled) {
+        textStyle = textStyle.copyWith(
+          color: SailTheme.of(context).colors.textTertiary,
+        );
+      }
+
+      visual = Row(
+        children: [
+          visual,
+          Padding(
+            padding: const EdgeInsets.only(left: 8.0),
+            child: Text(
+              widget.label!,
+              style: textStyle,
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (!enabled) return visual;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        widget.onChanged!(widget.value);
+      },
+      onTapDown: (_) {
+        setState(() {
+          _pressed = true;
+        });
+      },
+      onTapCancel: () {
+        setState(() {
+          _pressed = false;
+        });
+      },
+      onTapUp: (_) {
+        setState(() {
+          _pressed = false;
+        });
+      },
+      child: visual,
+    );
+  }
+}

--- a/packages/sail_ui/lib/widgets/inputs/text_field.dart
+++ b/packages/sail_ui/lib/widgets/inputs/text_field.dart
@@ -21,7 +21,9 @@ class SailTextField extends StatelessWidget {
   final TextFieldSize size;
   final void Function(String)? onSubmitted;
   final bool readOnly;
-
+  final bool dense;
+  final bool enabled;
+  
   const SailTextField({
     super.key,
     required this.controller,
@@ -38,6 +40,8 @@ class SailTextField extends StatelessWidget {
     this.focusNode,
     this.onSubmitted,
     this.readOnly = false,
+    this.dense = false,
+    this.enabled = true,
   });
 
   @override
@@ -64,6 +68,8 @@ class SailTextField extends StatelessWidget {
             child: SailText.secondary13(label!),
           ),
         TextField(
+          enabled: enabled,
+          mouseCursor: enabled ? WidgetStateMouseCursor.textable : SystemMouseCursors.forbidden,
           cursorColor: theme.colors.primary,
           cursorHeight: textSize,
           controller: controller,


### PR DESCRIPTION
Adds a transaction fee section to the send page and introduces the `stacked` package to manage state in a separate view model instead of in-widget. Tweaks some of the `sail_ui` components to better represent a disabled state.

Also adds a new `SailRadioButton<T>` component for a more Qt/desktop-like radio component.