### PR TITLE
drivechain-server: allow zero-value balance

### DIFF
--- a/drivechain-server/api/wallet/wallet.go
+++ b/drivechain-server/api/wallet/wallet.go
@@ -174,7 +174,11 @@ func (s *Server) GetBalance(ctx context.Context, c *connect.Request[emptypb.Empt
 		balanceValue = s.balance.Load()
 	}
 
-	balance := balanceValue.(bdk.Balance)
+	balance, ok := balanceValue.(bdk.Balance)
+	if !ok {
+		// If the balance is still nil or not of the expected type, return an error
+		return nil, connect.NewError(connect.CodeInternal, errors.New("balance not available"))
+	}
 
 	return connect.NewResponse(&pb.GetBalanceResponse{
 		ConfirmedSatoshi: uint64(balance.Confirmed),

--- a/drivechain-server/bdk/bdk.go
+++ b/drivechain-server/bdk/bdk.go
@@ -205,20 +205,20 @@ type Balance struct {
 	UntrustedPending btcutil.Amount `json:"untrusted_pending"`
 }
 
-func (w *Wallet) GetBalance(ctx context.Context) (Balance, error) {
+func (w *Wallet) GetBalance(ctx context.Context) (*Balance, error) {
 	res, err := w.execWallet(ctx, "get_balance")
 	if err != nil {
-		return Balance{}, err
+		return nil, err
 	}
 
 	var parsed struct {
 		Satoshi Balance `json:"satoshi"`
 	}
 	if err := json.Unmarshal(res, &parsed); err != nil {
-		return Balance{}, err
+		return nil, err
 	}
 
-	return parsed.Satoshi, err
+	return &parsed.Satoshi, err
 }
 
 // CreateTransaction creates a new transaction (but does not do any signing!).


### PR DESCRIPTION
Previously we would incorrectly return an error if the stored `atomic.Value` was a zero-value struct, this change adds a check and returns the zero-value balance instead.