### PR TITLE
drivechain_client: add sidechain activation management

### DIFF
--- a/packages/drivechain_client/lib/api.dart
+++ b/packages/drivechain_client/lib/api.dart
@@ -42,6 +42,7 @@ abstract class BitcoindAPI {
 
 abstract class DrivechainAPI {
   Future<List<ListSidechainsResponse_Sidechain>> listSidechains();
+  Future<List<SidechainProposal>> listSidechainProposals();
 }
 
 class APILive extends API {
@@ -248,6 +249,17 @@ class _DrivechainAPILive implements DrivechainAPI {
     } catch (e) {
       log.e('Error listing sidechains: $e');
       throw DrivechainException('Failed to list sidechains: ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<List<SidechainProposal>> listSidechainProposals() async {
+    try {
+      final response = await _client.listSidechainProposals(ListSidechainProposalsRequest());
+      return response.proposals;
+    } catch (e) {
+      log.e('Error listing sidechain proposals: $e');
+      throw DrivechainException('Failed to list sidechain proposals: ${e.toString()}');
     }
   }
 }

--- a/packages/drivechain_client/lib/pages/overview_page.dart
+++ b/packages/drivechain_client/lib/pages/overview_page.dart
@@ -225,8 +225,6 @@ class BalancesViewModel extends BaseViewModel {
   BalancesViewModel() {
     balanceProvider.addListener(notifyListeners);
     blockchainProvider.addListener(notifyListeners);
-
-    setErrorForObject('balance', 'test');
   }
 
   void errorListener() {
@@ -236,9 +234,6 @@ class BalancesViewModel extends BaseViewModel {
     if (blockchainProvider.error != null) {
       setErrorForObject('blockchain', blockchainProvider.error);
     }
-
-    // test
-    setErrorForObject('balance', 'test');
   }
 
   int get confirmedBalance => balanceProvider.balance;

--- a/packages/drivechain_client/lib/pages/send_page.dart
+++ b/packages/drivechain_client/lib/pages/send_page.dart
@@ -70,7 +70,8 @@ class SendPage extends StatelessWidget {
                           if (snapshot.hasData) {
                             final balance = formatBitcoin(
                               satoshiToBTC(
-                                snapshot.data!.confirmedSatoshi.toInt() + snapshot.data!.pendingSatoshi.toInt(),
+                                snapshot.data!.confirmedSatoshi.toInt() +
+                                    snapshot.data!.pendingSatoshi.toInt(),
                               ),
                             );
                             return SailText.primary12('Balance: $balance');
@@ -120,7 +121,8 @@ class SendDetailsForm extends ViewModelWidget<SendPageViewModel> {
             Expanded(
               child: SailTextField(
                 controller: viewModel.addressController,
-                hintText: 'Enter a Drivechain address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)',
+                hintText:
+                    'Enter a Drivechain address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)',
                 size: TextFieldSize.small,
               ),
             ),
@@ -131,7 +133,8 @@ class SendDetailsForm extends ViewModelWidget<SendPageViewModel> {
                   await SystemClipboard.instance?.read().then((reader) async {
                     if (reader.canProvide(Formats.plainText)) {
                       final text = await reader.readValue(Formats.plainText);
-                      viewModel.addressController.text = text ?? viewModel.addressController.text;
+                      viewModel.addressController.text =
+                          text ?? viewModel.addressController.text;
                     }
                   });
                 } else {
@@ -259,7 +262,8 @@ class TransactionFeeForm extends ViewModelWidget<SendPageViewModel> {
                   children: [
                     Row(
                       children: [
-                        SailText.primary12('${formatBitcoin(viewModel.feeRate)}/kvB'),
+                        SailText.primary12(
+                            '${formatBitcoin(viewModel.feeRate)}/kvB',),
                         const SizedBox(width: 8.0),
                       ],
                     ),
@@ -279,7 +283,8 @@ class TransactionFeeForm extends ViewModelWidget<SendPageViewModel> {
                               ),
                             );
                           }).toList(),
-                          onChanged: (value) => viewModel.setConfirmationTarget(value),
+                          onChanged: (value) =>
+                              viewModel.setConfirmationTarget(value),
                           value: viewModel.confirmationTarget,
                         ),
                       ],
@@ -318,7 +323,8 @@ class TransactionFeeForm extends ViewModelWidget<SendPageViewModel> {
                             child: NumericField(
                               controller: viewModel.customFeeController,
                               hintText: 'Custom fee',
-                              enabled: viewModel.feeType == 'custom' && !viewModel.useMinimumFee,
+                              enabled: viewModel.feeType == 'custom' &&
+                                  !viewModel.useMinimumFee,
                             ),
                           ),
                           const SizedBox(width: SailStyleValues.padding08),
@@ -447,7 +453,9 @@ class _NumericFieldState extends State<NumericField> {
       size: TextFieldSize.small,
       dense: true,
       enabled: widget.enabled,
-      onSubmitted: widget.onSubmitted != null ? (value) => widget.onSubmitted!(value) : null,
+      onSubmitted: widget.onSubmitted != null
+          ? (value) => widget.onSubmitted!(value)
+          : null,
     );
   }
 }
@@ -460,20 +468,25 @@ class QtIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SailScaleButton(
-      onPressed: onPressed,
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border.all(
-            color: Colors.grey,
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(4.0),
+      child: SailScaleButton(
+        color: context.sailTheme.colors.background,
+        onPressed: onPressed,
+        child: Container(
+          clipBehavior: Clip.hardEdge,
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.grey,
+            ),
+            borderRadius: BorderRadius.circular(4.0),
           ),
-          borderRadius: BorderRadius.circular(4.0),
+          padding: const EdgeInsets.symmetric(
+            horizontal: 4.0,
+            vertical: 4.0,
+          ),
+          child: icon,
         ),
-        padding: const EdgeInsets.symmetric(
-          horizontal: 4.0,
-          vertical: 4.0,
-        ),
-        child: icon,
       ),
     );
   }
@@ -482,7 +495,8 @@ class QtIconButton extends StatelessWidget {
 class SendPageViewModel extends BaseViewModel {
   BalanceProvider get balanceProvider => GetIt.I<BalanceProvider>();
   BlockchainProvider get blockchainProvider => GetIt.I<BlockchainProvider>();
-  TransactionProvider get transactionsProvider => GetIt.I<TransactionProvider>();
+  TransactionProvider get transactionsProvider =>
+      GetIt.I<TransactionProvider>();
   API get api => GetIt.I<API>();
   Logger get log => GetIt.I<Logger>();
   late TextEditingController addressController;
@@ -564,7 +578,8 @@ class SendPageViewModel extends BaseViewModel {
     setBusy(true);
     try {
       final estimate = await api.bitcoind.estimateSmartFee(confirmationTarget);
-      Logger().d('Estimate: estimate=${estimate.feeRate} errors=${estimate.errors}');
+      Logger().d(
+          'Estimate: estimate=${estimate.feeRate} errors=${estimate.errors}',);
       feeEstimate = estimate;
     } catch (error) {
       setError(error.toString());
@@ -592,8 +607,11 @@ class SendPageViewModel extends BaseViewModel {
     try {
       final txid = await api.wallet.sendTransaction(
         addressController.text,
-        btcToSatoshi(double.parse(amountController.text) - (subtractFee ? feeRate : 0)),
-        feeType == 'recommended' ? feeRate : double.parse(customFeeController.text),
+        btcToSatoshi(
+            double.parse(amountController.text) - (subtractFee ? feeRate : 0),),
+        feeType == 'recommended'
+            ? feeRate
+            : double.parse(customFeeController.text),
         replaceByFee,
       );
       Logger().d('Sent transaction: txid=$txid ');

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -8,20 +8,26 @@ import 'package:stacked/stacked.dart';
 import 'package:drivechain_client/providers/sidechain_provider.dart';
 import 'package:get_it/get_it.dart';
 import 'package:drivechain_client/gen/drivechain/v1/drivechain.pbgrpc.dart';
+import 'package:drivechain_client/pages/sidechain_proposal_page.dart';
 
 @RoutePage()
-class SidechainActivationManagementModal extends StatelessWidget {
-  const SidechainActivationManagementModal({super.key});
+class SidechainActivationManagementPage extends StatelessWidget {
+  const SidechainActivationManagementPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox(
-      height: 480,
-      width: 600,
-      child: QtPage(
-        child: Padding(
-          padding: EdgeInsets.all(SailStyleValues.padding08),
-          child: SidechainActivationManagementView(),
+    return ViewModelBuilder<SidechainActivationManagementViewModel>.reactive(
+      viewModelBuilder: () => SidechainActivationManagementViewModel(),
+      builder: (context, model, child) => QtPage(
+        child: Column(
+          children: [
+            // ... (existing widgets)
+            QtButton(
+              onPressed: () => showSidechainProposalModal(context),
+              child: SailText.primary13('Create Sidechain Proposal'),
+            ),
+            // ... (existing widgets)
+          ],
         ),
       ),
     );
@@ -84,7 +90,8 @@ class SidechainActivationManagementView extends StatelessWidget {
                   SailTableCell(child: SailText.primary12('Yes')),
                   SailTableCell(child: SailText.primary12(sidechain.title)),
                   SailTableCell(
-                      child: SailText.primary12(sidechain.chaintipTxid.isEmpty ? 'N/A' : sidechain.chaintipTxid),),
+                    child: SailText.primary12(sidechain.chaintipTxid.isEmpty ? 'N/A' : sidechain.chaintipTxid),
+                  ),
                   //TODO: SailTableCell(child: SailText.primary12('TODO')),
                 ];
               },
@@ -188,7 +195,21 @@ Future<void> showSidechainActivationManagementModal(BuildContext context) {
         child: Material(
           clipBehavior: Clip.antiAlias,
           borderRadius: BorderRadius.circular(4.0),
-          child: const SidechainActivationManagementModal(),
+          child: const SidechainActivationManagementPage(),
+        ),
+      );
+    },
+  );
+}
+
+Future<void> showSidechainProposalModal(BuildContext context) async {
+  await showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return Dialog(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 800),
+          child: const SidechainProposalView(),
         ),
       );
     },

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -33,6 +33,8 @@ class SidechainActivationManagementViewModel extends BaseViewModel {
       .cast<ListSidechainsResponse_Sidechain>()
       .toList();
 
+  List<SidechainProposal> get sidechainProposals => sidechainProvider.sidechainProposals;
+
   SidechainActivationManagementViewModel() {
     sidechainProvider.addListener(notifyListeners);
   }
@@ -127,18 +129,20 @@ class SidechainActivationManagementView extends StatelessWidget {
                 SailTableHeaderCell(child: SailText.primary12('Fails')),
                 SailTableHeaderCell(child: SailText.primary12('Hash')),
               ],
-              rowBuilder: (context, row, selected) => [
-                // TODO: Get actual data
-                SailTableCell(child: SailText.primary12('Row $row, Col 1')),
-                SailTableCell(child: SailText.primary12('Row $row, Col 2')),
-                SailTableCell(child: SailText.primary12('Row $row, Col 3')),
-                SailTableCell(child: SailText.primary12('Row $row, Col 4')),
-                SailTableCell(child: SailText.primary12('Row $row, Col 5')),
-                SailTableCell(child: SailText.primary12('Row $row, Col 6')),
-                SailTableCell(child: SailText.primary12('Row $row, Col 7')),
-                SailTableCell(child: SailText.primary12('Row $row, Col 8')),
-              ],
-              rowCount: 10, // Example row count
+              rowBuilder: (context, row, selected) {
+                final proposal = model.sidechainProposals[row];
+                return [
+                  SailTableCell(child: SailText.primary12(proposal.voteCount.toString())),
+                  SailTableCell(child: SailText.primary12(proposal.slot.toString())),
+                  SailTableCell(child: SailText.primary12('Replacement')),
+                  SailTableCell(child: SailText.primary12(proposal.data.toString())),
+                  SailTableCell(child: SailText.primary12('Description')),
+                  SailTableCell(child: SailText.primary12(proposal.proposalAge.toString())),
+                  SailTableCell(child: SailText.primary12(proposal.proposalHeight.toString())),
+                  SailTableCell(child: SailText.primary12(proposal.dataHash)),
+                ];
+              },
+              rowCount: model.sidechainProposals.length,
               columnCount: 8,
               columnWidths: const [50, 50, 100, 100, 200, 50, 50, 200],
             ),

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -4,6 +4,10 @@ import 'package:drivechain_client/widgets/qt_page.dart';
 import 'package:drivechain_client/widgets/qt_button.dart';
 import 'package:flutter/material.dart';
 import 'package:sail_ui/sail_ui.dart';
+import 'package:stacked/stacked.dart';
+import 'package:drivechain_client/providers/sidechain_provider.dart';
+import 'package:get_it/get_it.dart';
+import 'package:drivechain_client/gen/drivechain/v1/drivechain.pbgrpc.dart';
 
 @RoutePage()
 class SidechainActivationManagementModal extends StatelessWidget {
@@ -24,125 +28,157 @@ class SidechainActivationManagementModal extends StatelessWidget {
   }
 }
 
+class SidechainActivationManagementViewModel extends BaseViewModel {
+  final SidechainProvider sidechainProvider = GetIt.I.get<SidechainProvider>();
+
+  List<ListSidechainsResponse_Sidechain> get activeSidechains => sidechainProvider.sidechains
+      .where((sidechain) => sidechain != null)
+      .cast<ListSidechainsResponse_Sidechain>()
+      .toList();
+
+  SidechainActivationManagementViewModel() {
+    sidechainProvider.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    sidechainProvider.removeListener(notifyListeners);
+    super.dispose();
+  }
+}
+
 class SidechainActivationManagementView extends StatelessWidget {
   const SidechainActivationManagementView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SailText.primary12('Escrow Status (Active Sidechains)'),
-        const SizedBox(height: SailStyleValues.padding08),
-        Container(
-          decoration: BoxDecoration(
-            color: context.sailTheme.colors.background,
-            border: Border.all(
-              color: context.sailTheme.colors.divider,
-              width: 1.0,
+    return ViewModelBuilder<SidechainActivationManagementViewModel>.reactive(
+      viewModelBuilder: () => SidechainActivationManagementViewModel(),
+      builder: (context, model, child) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SailText.primary12('Escrow Status (Active Sidechains)'),
+          const SizedBox(height: SailStyleValues.padding08),
+          Container(
+            decoration: BoxDecoration(
+              color: context.sailTheme.colors.background,
+              border: Border.all(
+                color: context.sailTheme.colors.divider,
+                width: 1.0,
+              ),
+              borderRadius: BorderRadius.circular(4.0),
             ),
-            borderRadius: BorderRadius.circular(4.0),
-          ),
-          height: 150,
-          child: SailTable(
-            headerBuilder: (context) => [
-              SailTableHeaderCell(child: SailText.primary12('#')),
-              SailTableHeaderCell(child: SailText.primary12('Active')),
-              SailTableHeaderCell(child: SailText.primary12('Name')),
-              SailTableHeaderCell(child: SailText.primary12('CTIP TxID')),
-              SailTableHeaderCell(child: SailText.primary12('CTIP Index')),
-            ],
-            rowBuilder: (context, row, selected) => [
-              SailTableCell(child: SailText.primary12('Row $row, Col 1')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 2')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 3')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 4')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 5')),
-            ],
-            rowCount: 10, // Example row count
-            columnCount: 5,
-            columnWidths: const [50, 50, 100, 200, 100],
-          ),
-        ),
-        const SizedBox(height: SailStyleValues.padding15),
-        SailText.primary12('Pending Sidechain Proposals'),
-        const SizedBox(height: SailStyleValues.padding08),
-        Container(
-          clipBehavior: Clip.antiAlias,
-          decoration: BoxDecoration(
-            color: context.sailTheme.colors.background,
-            border: Border.all(
-              color: context.sailTheme.colors.divider,
-              width: 1.0,
-            ),
-            borderRadius: BorderRadius.circular(4.0),
-          ),
-          height: 150,
-          child: SailTable(
-            headerBuilder: (context) => [
-              SailTableHeaderCell(child: SailText.primary12('Vote')),
-              SailTableHeaderCell(child: SailText.primary12('SC #')),
-              SailTableHeaderCell(child: SailText.primary12('Replacement')),
-              SailTableHeaderCell(child: SailText.primary12('Title')),
-              SailTableHeaderCell(child: SailText.primary12('Description')),
-              SailTableHeaderCell(child: SailText.primary12('Age')),
-              SailTableHeaderCell(child: SailText.primary12('Fails')),
-              SailTableHeaderCell(child: SailText.primary12('Hash')),
-            ],
-            rowBuilder: (context, row, selected) => [
-              SailTableCell(child: SailText.primary12('Row $row, Col 1')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 2')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 3')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 4')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 5')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 6')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 7')),
-              SailTableCell(child: SailText.primary12('Row $row, Col 8')),
-            ],
-            rowCount: 10, // Example row count
-            columnCount: 8,
-            columnWidths: const [50, 50, 100, 100, 200, 50, 50, 200],
-          ),
-        ),
-        const SizedBox(height: SailStyleValues.padding30),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                QtButton(
-                  onPressed: () {},
-                  child: SailText.primary13('ACK'),
-                ),
-                const SizedBox(width: SailStyleValues.padding15),
-                QtButton(
-                  onPressed: () {},
-                  child: SailText.primary13('NACK'),
-                ),
+            height: 150,
+            child: SailTable(
+              headerBuilder: (context) => [
+                SailTableHeaderCell(child: SailText.primary12('#')),
+                SailTableHeaderCell(child: SailText.primary12('Active')),
+                SailTableHeaderCell(child: SailText.primary12('Name')),
+                SailTableHeaderCell(child: SailText.primary12('CTIP TxID')),
+                //TODO: SailTableHeaderCell(child: SailText.primary12('CTIP Index')),
               ],
+              rowBuilder: (context, row, selected) {
+                final sidechain = model.activeSidechains[row];
+                return [
+                  SailTableCell(child: SailText.primary12('${sidechain.slot}')),
+                  SailTableCell(child: SailText.primary12('Yes')),
+                  SailTableCell(child: SailText.primary12(sidechain.title)),
+                  SailTableCell(
+                      child: SailText.primary12(sidechain.chaintipTxid.isEmpty ? 'N/A' : sidechain.chaintipTxid),),
+                  //TODO: SailTableCell(child: SailText.primary12('TODO')),
+                ];
+              },
+              rowCount: model.activeSidechains.length,
+              columnCount: 4, // TODO: 5
+              columnWidths: const [50, 100, 100, 500],
             ),
-            Row(
-              children: [
-                QtButton(
-                  onPressed: () {},
-                  child: SailText.primary13('Create Sidechain Proposal'),
-                ),
-                const SizedBox(width: SailStyleValues.padding15),
-                QtIconButton(
-                  icon: const Icon(Icons.question_mark_rounded, size: 13),
-                  onPressed: () {},
-                ),
+          ),
+          const SizedBox(height: SailStyleValues.padding15),
+          SailText.primary12('Pending Sidechain Proposals'),
+          const SizedBox(height: SailStyleValues.padding08),
+          Container(
+            clipBehavior: Clip.antiAlias,
+            decoration: BoxDecoration(
+              color: context.sailTheme.colors.background,
+              border: Border.all(
+                color: context.sailTheme.colors.divider,
+                width: 1.0,
+              ),
+              borderRadius: BorderRadius.circular(4.0),
+            ),
+            height: 150,
+            child: SailTable(
+              headerBuilder: (context) => [
+                SailTableHeaderCell(child: SailText.primary12('Vote')),
+                SailTableHeaderCell(child: SailText.primary12('SC #')),
+                SailTableHeaderCell(child: SailText.primary12('Replacement')),
+                SailTableHeaderCell(child: SailText.primary12('Title')),
+                SailTableHeaderCell(child: SailText.primary12('Description')),
+                SailTableHeaderCell(child: SailText.primary12('Age')),
+                SailTableHeaderCell(child: SailText.primary12('Fails')),
+                SailTableHeaderCell(child: SailText.primary12('Hash')),
               ],
+              rowBuilder: (context, row, selected) => [
+                // TODO: Get actual data
+                SailTableCell(child: SailText.primary12('Row $row, Col 1')),
+                SailTableCell(child: SailText.primary12('Row $row, Col 2')),
+                SailTableCell(child: SailText.primary12('Row $row, Col 3')),
+                SailTableCell(child: SailText.primary12('Row $row, Col 4')),
+                SailTableCell(child: SailText.primary12('Row $row, Col 5')),
+                SailTableCell(child: SailText.primary12('Row $row, Col 6')),
+                SailTableCell(child: SailText.primary12('Row $row, Col 7')),
+                SailTableCell(child: SailText.primary12('Row $row, Col 8')),
+              ],
+              rowCount: 10, // Example row count
+              columnCount: 8,
+              columnWidths: const [50, 50, 100, 100, 200, 50, 50, 200],
             ),
-          ],
-        ),
-      ],
+          ),
+          const SizedBox(height: SailStyleValues.padding30),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  QtButton(
+                    onPressed: () {},
+                    child: SailText.primary13('ACK'),
+                  ),
+                  const SizedBox(width: SailStyleValues.padding15),
+                  QtButton(
+                    onPressed: () {},
+                    child: SailText.primary13('NACK'),
+                  ),
+                ],
+              ),
+              Row(
+                children: [
+                  QtButton(
+                    onPressed: () {
+                      showSnackBar(context, 'Not implemented');
+                    },
+                    child: SailText.primary13('Create Sidechain Proposal'),
+                  ),
+                  const SizedBox(width: SailStyleValues.padding15),
+                  QtIconButton(
+                    icon: const Icon(Icons.question_mark_rounded, size: 13),
+                    onPressed: () {
+                      showSnackBar(context, 'Not implemented');
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }
 
 Future<void> showSidechainActivationManagementModal(BuildContext context) {
-  return showDialog<void>(
+  return showAdaptiveDialog<void>(
+    barrierDismissible: true,
     context: context,
     builder: (BuildContext context) {
       return Padding(

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -45,15 +45,14 @@ class SidechainActivationManagementViewModel extends BaseViewModel {
     super.dispose();
   }
 
-  // New placeholder functions
-  void ack() {
-    // TODO: Implement ACK functionality
-    print('ACK function called');
+  // TODO: Implement the actual API call to ACK the sidechain
+  void ack(BuildContext context) {
+    showSnackBar(context, 'ACK not implemented');
   }
 
-  void nack() {
-    // TODO: Implement NACK functionality
-    print('NACK function called');
+  // TODO: Implement the actual API call to NACK the sidechain
+  void nack(BuildContext context) {
+    showSnackBar(context, 'NACK not implemented');
   }
 }
 
@@ -79,6 +78,7 @@ class SidechainActivationManagementView extends StatelessWidget {
               borderRadius: BorderRadius.circular(4.0),
             ),
             height: 150,
+            
             child: SailTable(
               headerBuilder: (context) => [
                 SailTableHeaderCell(child: SailText.primary12('#')),
@@ -88,6 +88,8 @@ class SidechainActivationManagementView extends StatelessWidget {
                 //TODO: SailTableHeaderCell(child: SailText.primary12('CTIP Index')),
               ],
               rowBuilder: (context, row, selected) {
+                // TODO: Revise the data, it's not yet clear what is what. The columns is taken straight from
+                // drivechain-qt and might not be available in the API.
                 final sidechain = model.activeSidechains[row];
                 return [
                   SailTableCell(child: SailText.primary12('${sidechain.slot}')),
@@ -131,6 +133,8 @@ class SidechainActivationManagementView extends StatelessWidget {
               ],
               rowBuilder: (context, row, selected) {
                 final proposal = model.sidechainProposals[row];
+                // TODO: Revise the data, it's not yet clear what is what. The columns is taken straight from
+                // drivechain-qt and might not be available in the API.
                 return [
                   SailTableCell(child: SailText.primary12(proposal.voteCount.toString())),
                   SailTableCell(child: SailText.primary12(proposal.slot.toString())),
@@ -154,12 +158,12 @@ class SidechainActivationManagementView extends StatelessWidget {
               Row(
                 children: [
                   QtButton(
-                    onPressed: () => model.ack(),
+                    onPressed: () => model.ack(context),
                     child: SailText.primary13('ACK'),
                   ),
                   const SizedBox(width: SailStyleValues.padding15),
                   QtButton(
-                    onPressed: () => model.nack(),
+                    onPressed: () => model.nack(context),
                     child: SailText.primary13('NACK'),
                   ),
                 ],

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -19,16 +19,7 @@ class SidechainActivationManagementPage extends StatelessWidget {
     return ViewModelBuilder<SidechainActivationManagementViewModel>.reactive(
       viewModelBuilder: () => SidechainActivationManagementViewModel(),
       builder: (context, model, child) => QtPage(
-        child: Column(
-          children: [
-            // ... (existing widgets)
-            QtButton(
-              onPressed: () => showSidechainProposalModal(context),
-              child: SailText.primary13('Create Sidechain Proposal'),
-            ),
-            // ... (existing widgets)
-          ],
-        ),
+        child: SidechainActivationManagementView(),
       ),
     );
   }
@@ -162,7 +153,7 @@ class SidechainActivationManagementView extends StatelessWidget {
                 children: [
                   QtButton(
                     onPressed: () {
-                      showSnackBar(context, 'Not implemented');
+                      showSidechainProposalModal(context);
                     },
                     child: SailText.primary13('Create Sidechain Proposal'),
                   ),
@@ -202,16 +193,3 @@ Future<void> showSidechainActivationManagementModal(BuildContext context) {
   );
 }
 
-Future<void> showSidechainProposalModal(BuildContext context) async {
-  await showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return Dialog(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 800),
-          child: const SidechainProposalView(),
-        ),
-      );
-    },
-  );
-}

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -1,0 +1,160 @@
+import 'package:auto_route/annotations.dart';
+import 'package:drivechain_client/pages/send_page.dart';
+import 'package:drivechain_client/widgets/qt_page.dart';
+import 'package:drivechain_client/widgets/qt_button.dart';
+import 'package:flutter/material.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+@RoutePage()
+class SidechainActivationManagementModal extends StatelessWidget {
+  const SidechainActivationManagementModal({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      height: 480,
+      width: 600,
+      child: QtPage(
+        child: Padding(
+          padding: EdgeInsets.all(SailStyleValues.padding08),
+          child: SidechainActivationManagementView(),
+        ),
+      ),
+    );
+  }
+}
+
+class SidechainActivationManagementView extends StatelessWidget {
+  const SidechainActivationManagementView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SailText.primary12('Escrow Status (Active Sidechains)'),
+        const SizedBox(height: SailStyleValues.padding08),
+        Container(
+          decoration: BoxDecoration(
+            color: context.sailTheme.colors.background,
+            border: Border.all(
+              color: context.sailTheme.colors.divider,
+              width: 1.0,
+            ),
+            borderRadius: BorderRadius.circular(4.0),
+          ),
+          height: 150,
+          child: SailTable(
+            headerBuilder: (context) => [
+              SailTableHeaderCell(child: SailText.primary12('#')),
+              SailTableHeaderCell(child: SailText.primary12('Active')),
+              SailTableHeaderCell(child: SailText.primary12('Name')),
+              SailTableHeaderCell(child: SailText.primary12('CTIP TxID')),
+              SailTableHeaderCell(child: SailText.primary12('CTIP Index')),
+            ],
+            rowBuilder: (context, row, selected) => [
+              SailTableCell(child: SailText.primary12('Row $row, Col 1')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 2')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 3')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 4')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 5')),
+            ],
+            rowCount: 10, // Example row count
+            columnCount: 5,
+            columnWidths: const [50, 50, 100, 200, 100],
+          ),
+        ),
+        const SizedBox(height: SailStyleValues.padding15),
+        SailText.primary12('Pending Sidechain Proposals'),
+        const SizedBox(height: SailStyleValues.padding08),
+        Container(
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            color: context.sailTheme.colors.background,
+            border: Border.all(
+              color: context.sailTheme.colors.divider,
+              width: 1.0,
+            ),
+            borderRadius: BorderRadius.circular(4.0),
+          ),
+          height: 150,
+          child: SailTable(
+            headerBuilder: (context) => [
+              SailTableHeaderCell(child: SailText.primary12('Vote')),
+              SailTableHeaderCell(child: SailText.primary12('SC #')),
+              SailTableHeaderCell(child: SailText.primary12('Replacement')),
+              SailTableHeaderCell(child: SailText.primary12('Title')),
+              SailTableHeaderCell(child: SailText.primary12('Description')),
+              SailTableHeaderCell(child: SailText.primary12('Age')),
+              SailTableHeaderCell(child: SailText.primary12('Fails')),
+              SailTableHeaderCell(child: SailText.primary12('Hash')),
+            ],
+            rowBuilder: (context, row, selected) => [
+              SailTableCell(child: SailText.primary12('Row $row, Col 1')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 2')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 3')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 4')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 5')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 6')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 7')),
+              SailTableCell(child: SailText.primary12('Row $row, Col 8')),
+            ],
+            rowCount: 10, // Example row count
+            columnCount: 8,
+            columnWidths: const [50, 50, 100, 100, 200, 50, 50, 200],
+          ),
+        ),
+        const SizedBox(height: SailStyleValues.padding30),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                QtButton(
+                  onPressed: () {},
+                  child: SailText.primary13('ACK'),
+                ),
+                const SizedBox(width: SailStyleValues.padding15),
+                QtButton(
+                  onPressed: () {},
+                  child: SailText.primary13('NACK'),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                QtButton(
+                  onPressed: () {},
+                  child: SailText.primary13('Create Sidechain Proposal'),
+                ),
+                const SizedBox(width: SailStyleValues.padding15),
+                QtIconButton(
+                  icon: const Icon(Icons.question_mark_rounded, size: 13),
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> showSidechainActivationManagementModal(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (BuildContext context) {
+      return Padding(
+        padding: EdgeInsets.all(
+          MediaQuery.of(context).size.width * 0.1,
+        ),
+        child: Material(
+          clipBehavior: Clip.antiAlias,
+          borderRadius: BorderRadius.circular(4.0),
+          child: const SidechainActivationManagementModal(),
+        ),
+      );
+    },
+  );
+}

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -42,6 +42,17 @@ class SidechainActivationManagementViewModel extends BaseViewModel {
     sidechainProvider.removeListener(notifyListeners);
     super.dispose();
   }
+
+  // New placeholder functions
+  void ack() {
+    // TODO: Implement ACK functionality
+    print('ACK function called');
+  }
+
+  void nack() {
+    // TODO: Implement NACK functionality
+    print('NACK function called');
+  }
 }
 
 class SidechainActivationManagementView extends StatelessWidget {
@@ -139,12 +150,12 @@ class SidechainActivationManagementView extends StatelessWidget {
               Row(
                 children: [
                   QtButton(
-                    onPressed: () {},
+                    onPressed: () => model.ack(),
                     child: SailText.primary13('ACK'),
                   ),
                   const SizedBox(width: SailStyleValues.padding15),
                   QtButton(
-                    onPressed: () {},
+                    onPressed: () => model.nack(),
                     child: SailText.primary13('NACK'),
                   ),
                 ],
@@ -192,4 +203,3 @@ Future<void> showSidechainActivationManagementModal(BuildContext context) {
     },
   );
 }
-

--- a/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
@@ -1,0 +1,310 @@
+import 'package:drivechain_client/pages/send_page.dart';
+import 'package:drivechain_client/widgets/qt_page.dart';
+import 'package:flutter/material.dart';
+import 'package:auto_route/annotations.dart';
+import 'package:sail_ui/sail_ui.dart';
+import 'package:stacked/stacked.dart';
+import 'package:drivechain_client/widgets/qt_container.dart';
+import 'package:drivechain_client/widgets/qt_button.dart';
+
+@RoutePage()
+class SidechainProposalPage extends StatelessWidget {
+  const SidechainProposalPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const QtPage(
+      child: SidechainProposalView(),
+    );
+  }
+}
+
+class SidechainProposalView extends StatelessWidget {
+  const SidechainProposalView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<SidechainProposalViewModel>.reactive(
+      viewModelBuilder: () => SidechainProposalViewModel(),
+      builder: (context, model, child) {
+        return SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(SailStyleValues.padding15),
+            child: Form(
+              key: model.formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (model.hasErrorForKey('proposal')) ...{
+                    SailText.primary12(
+                      'Failed to propose sidechain: ${model.error('proposal')}',
+                      color: context.sailTheme.colors.error,
+                    ),
+                  },
+                  SailText.primary20('Create Sidechain Proposal'),
+                  const SizedBox(height: SailStyleValues.padding25),
+                  _buildRequiredSection(context, model),
+                  const SizedBox(height: SailStyleValues.padding25),
+                  _buildOptionalSection(context, model),
+                  const SizedBox(height: SailStyleValues.padding25),
+                  QtButton(
+                    onPressed: () {
+                      if (model.formKey.currentState!.validate()) {
+                        model.proposeSidechain(context);
+                      }
+                    },
+                    child: model.isProposing
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : SailText.primary13('Propose Sidechain'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildRequiredSection(BuildContext context, SidechainProposalViewModel model) {
+    return QtContainer(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SailText.primary15('Required'),
+          const SizedBox(height: SailStyleValues.padding15),
+          Row(
+            children: [
+              Expanded(
+                flex: 1,
+                child: SailTextFormField(
+                  label: 'Slot #',
+                  controller: model.slotController,
+                  hintText: '0-255',
+                  keyboardType: TextInputType.number,
+                  validator: (value) => model.validateSlot(value),
+                  errorText: model.slotError,
+                ),
+              ),
+              const SizedBox(width: SailStyleValues.padding15),
+              Expanded(
+                flex: 3,
+                child: SailTextFormField(
+                  label: 'Title',
+                  hintText: 'Sidechain title',
+                  controller: model.titleController,
+                  validator: (value) => model.validateTitle(value),
+                  errorText: model.titleError,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOptionalSection(BuildContext context, SidechainProposalViewModel model) {
+    return QtContainer(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              SailText.primary15('Optional (but recommended)'),
+              const SizedBox(width: SailStyleValues.padding08),
+              QtIconButton(
+                icon: const Icon(Icons.info_outline, size: 16),
+                onPressed: () => _showInfoDialog(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: SailStyleValues.padding15),
+          SailTextFormField(
+            label: 'Description',
+            hintText: 'Sidechain description',
+            controller: model.descriptionController,
+            maxLines: 5,
+          ),
+          const SizedBox(height: SailStyleValues.padding15),
+          SailTextFormField(
+            label: 'Version',
+            hintText: '0',
+            controller: model.versionController,
+            keyboardType: TextInputType.number,
+            validator: (value) => model.validateVersion(value),
+            errorText: model.versionError,
+          ),
+          const SizedBox(height: SailStyleValues.padding15),
+          SailTextFormField(
+            label: 'Release tarball hash (256 bits)',
+            hintText: 'Gitian build tarball hash (Linux x86-64)',
+            controller: model.tarballHashController,
+            validator: (value) => model.validateHash(value, 256),
+            errorText: model.tarballHashError,
+          ),
+          const SizedBox(height: SailStyleValues.padding15),
+          SailTextFormField(
+            label: 'Build commit hash (160 bits)',
+            hintText: 'Gitian build commit hash',
+            controller: model.commitHashController,
+            validator: (value) => model.validateHash(value, 160),
+            errorText: model.commitHashError,
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showInfoDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Optional Fields'),
+          content: const Text(
+            'These fields are optional but recommended. They provide additional information about your sidechain proposal, which can help others understand and evaluate it better.',
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Close'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class SidechainProposalViewModel extends BaseViewModel {
+  final formKey = GlobalKey<FormState>();
+  final slotController = TextEditingController();
+  final titleController = TextEditingController();
+  final descriptionController = TextEditingController();
+  final versionController = TextEditingController();
+  final tarballHashController = TextEditingController();
+  final commitHashController = TextEditingController();
+
+  String? slotError;
+  String? titleError;
+  String? versionError;
+  String? tarballHashError;
+  String? commitHashError;
+
+  bool isProposing = false;
+
+  SidechainProposalViewModel() {
+    slotController.addListener(notifyListeners);
+    titleController.addListener(notifyListeners);
+    versionController.addListener(notifyListeners);
+    tarballHashController.addListener(notifyListeners);
+    commitHashController.addListener(notifyListeners);
+  }
+
+  bool get isFormValid {
+    return formKey.currentState?.validate() ?? false;
+  }
+
+  String? validateSlot(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Slot number is required';
+    }
+    final intValue = int.tryParse(value);
+    if (intValue == null || intValue < 0 || intValue > 255) {
+      return 'Slot must be between 0 and 255';
+    }
+    return null;
+  }
+
+  String? validateTitle(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Title is required';
+    }
+    return null;
+  }
+
+  String? validateVersion(String? value) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    final intValue = int.tryParse(value);
+    if (intValue == null || intValue < 0) {
+      return 'Version must be a positive integer';
+    }
+    return null;
+  }
+
+  String? validateHash(String? value, int bits) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    if (value.length != bits ~/ 4) {
+      return 'Hash must be $bits bits long';
+    }
+    if (!RegExp(r'^[a-fA-F0-9]+$').hasMatch(value)) {
+      return 'Hash must contain only hexadecimal characters';
+    }
+    return null;
+  }
+
+  Future<void> proposeSidechain(BuildContext context) async {
+    if (!isFormValid) return;
+
+    isProposing = true;
+    notifyListeners();
+
+    try {
+      // TODO: Implement the actual API call to propose the sidechain
+      await Future.delayed(const Duration(seconds: 2)); // Simulating API call
+
+      // If successful, close the modal
+      if (context.mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      // Handle error
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to propose sidechain: $e')),
+        );
+      }
+
+      setErrorForObject('proposal', e);
+    } finally {
+      isProposing = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    slotController.dispose();
+    titleController.dispose();
+    descriptionController.dispose();
+    versionController.dispose();
+    tarballHashController.dispose();
+    commitHashController.dispose();
+    super.dispose();
+  }
+}
+
+Future<void> showSidechainProposalModal(BuildContext context) async {
+  await showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return Dialog(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 800),
+          child: const SidechainProposalView(),
+        ),
+      );
+    },
+  );
+}

--- a/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
@@ -41,7 +41,7 @@ class SidechainProposalView extends StatelessWidget {
                       color: context.sailTheme.colors.error,
                     ),
                   },
-                  SailText.primary20('Create Sidechain Proposal'),
+                  SailText.primary12('Create Sidechain Proposal'),
                   const SizedBox(height: SailStyleValues.padding25),
                   _buildRequiredSection(context, model),
                   const SizedBox(height: SailStyleValues.padding25),
@@ -75,7 +75,7 @@ class SidechainProposalView extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SailText.primary15('Required'),
+          SailText.primary12('Required'),
           const SizedBox(height: SailStyleValues.padding15),
           Row(
             children: [
@@ -88,6 +88,7 @@ class SidechainProposalView extends StatelessWidget {
                   keyboardType: TextInputType.number,
                   validator: (value) => model.validateSlot(value),
                   errorText: model.slotError,
+                  size: TextFieldSize.small,
                 ),
               ),
               const SizedBox(width: SailStyleValues.padding15),
@@ -99,6 +100,7 @@ class SidechainProposalView extends StatelessWidget {
                   controller: model.titleController,
                   validator: (value) => model.validateTitle(value),
                   errorText: model.titleError,
+                  size: TextFieldSize.small,
                 ),
               ),
             ],
@@ -115,7 +117,7 @@ class SidechainProposalView extends StatelessWidget {
         children: [
           Row(
             children: [
-              SailText.primary15('Optional (but recommended)'),
+              SailText.primary12('Optional (but recommended)'),
               const SizedBox(width: SailStyleValues.padding08),
               QtIconButton(
                 icon: const Icon(Icons.info_outline, size: 16),
@@ -129,6 +131,7 @@ class SidechainProposalView extends StatelessWidget {
             hintText: 'Sidechain description',
             controller: model.descriptionController,
             maxLines: 5,
+            size: TextFieldSize.small,
           ),
           const SizedBox(height: SailStyleValues.padding15),
           SailTextFormField(
@@ -138,6 +141,7 @@ class SidechainProposalView extends StatelessWidget {
             keyboardType: TextInputType.number,
             validator: (value) => model.validateVersion(value),
             errorText: model.versionError,
+            size: TextFieldSize.small,
           ),
           const SizedBox(height: SailStyleValues.padding15),
           SailTextFormField(
@@ -146,6 +150,7 @@ class SidechainProposalView extends StatelessWidget {
             controller: model.tarballHashController,
             validator: (value) => model.validateHash(value, 256),
             errorText: model.tarballHashError,
+            size: TextFieldSize.small,
           ),
           const SizedBox(height: SailStyleValues.padding15),
           SailTextFormField(
@@ -154,6 +159,7 @@ class SidechainProposalView extends StatelessWidget {
             controller: model.commitHashController,
             validator: (value) => model.validateHash(value, 160),
             errorText: model.commitHashError,
+            size: TextFieldSize.small,
           ),
         ],
       ),
@@ -295,14 +301,20 @@ class SidechainProposalViewModel extends BaseViewModel {
   }
 }
 
-Future<void> showSidechainProposalModal(BuildContext context) async {
-  await showDialog(
+Future<void> showSidechainProposalModal(BuildContext context) {
+  return showAdaptiveDialog<void>(
+    barrierDismissible: true,
     context: context,
     builder: (BuildContext context) {
-      return Dialog(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 800),
-          child: const SidechainProposalView(),
+      return Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: MediaQuery.of(context).size.width * 0.2,
+          vertical: MediaQuery.of(context).size.height * 0.01,
+        ),
+        child: Material(
+          clipBehavior: Clip.antiAlias,
+          borderRadius: BorderRadius.circular(4.0),
+          child: const SidechainProposalPage(),
         ),
       );
     },

--- a/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
@@ -1,7 +1,9 @@
+import 'package:drivechain_client/api.dart';
 import 'package:drivechain_client/pages/send_page.dart';
 import 'package:drivechain_client/widgets/qt_page.dart';
 import 'package:flutter/material.dart';
 import 'package:auto_route/annotations.dart';
+import 'package:get_it/get_it.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:stacked/stacked.dart';
 import 'package:drivechain_client/widgets/qt_container.dart';
@@ -41,10 +43,21 @@ class SidechainProposalView extends StatelessWidget {
                       color: context.sailTheme.colors.error,
                     ),
                   },
-                  SailText.primary12('Create Sidechain Proposal'),
-                  const SizedBox(height: SailStyleValues.padding25),
+                  SailText.primary12('Required'),
+                  const SizedBox(height: SailStyleValues.padding08),
                   _buildRequiredSection(context, model),
                   const SizedBox(height: SailStyleValues.padding25),
+                  Row(
+                    children: [
+                      SailText.primary12('Optional (but recommended)'),
+                      const SizedBox(width: SailStyleValues.padding08),
+                      QtIconButton(
+                        icon: const Icon(Icons.info_outline, size: 16),
+                        onPressed: () => _showInfoDialog(context),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: SailStyleValues.padding08),
                   _buildOptionalSection(context, model),
                   const SizedBox(height: SailStyleValues.padding25),
                   QtButton(
@@ -55,9 +68,9 @@ class SidechainProposalView extends StatelessWidget {
                     },
                     child: model.isProposing
                         ? const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
+                            width: 13,
+                            height: 13,
+                            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
                           )
                         : SailText.primary13('Propose Sidechain'),
                   ),
@@ -75,9 +88,8 @@ class SidechainProposalView extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SailText.primary12('Required'),
-          const SizedBox(height: SailStyleValues.padding15),
           Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Expanded(
                 flex: 1,
@@ -115,17 +127,6 @@ class SidechainProposalView extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              SailText.primary12('Optional (but recommended)'),
-              const SizedBox(width: SailStyleValues.padding08),
-              QtIconButton(
-                icon: const Icon(Icons.info_outline, size: 16),
-                onPressed: () => _showInfoDialog(context),
-              ),
-            ],
-          ),
-          const SizedBox(height: SailStyleValues.padding15),
           SailTextFormField(
             label: 'Description',
             hintText: 'Sidechain description',
@@ -167,22 +168,61 @@ class SidechainProposalView extends StatelessWidget {
   }
 
   void _showInfoDialog(BuildContext context) {
-    showDialog(
+    showAdaptiveDialog(
       context: context,
+      barrierDismissible: true,
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('Optional Fields'),
-          content: const Text(
-            'These fields are optional but recommended. They provide additional information about your sidechain proposal, which can help others understand and evaluate it better.',
-          ),
-          actions: <Widget>[
-            TextButton(
-              child: const Text('Close'),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
+        return Center(
+          child: Material(
+            clipBehavior: Clip.antiAlias,
+            borderRadius: BorderRadius.circular(4.0),
+            child: QtPage(
+              child: Stack(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(SailStyleValues.padding15),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        SailText.primary12('''
+These fields are optional but highly recommended.
+
+Description:
+Brief description of the sidechain's purpose and where to find more information.
+
+Release tarball hash:
+Hash of the original gitian software build of this sidechain.
+Use the sha256sum utility to generate this hash, or copy the hash when it is printed to the console after gitian builds complete.
+
+Example:
+sha256sum Drivechain-12.0.21.00-x86_64-linux-gnu.tar.gz
+
+Result:
+fd9637e427f1e967cc658bfe1a836d537346ce3a6dd0746878129bb5bc646680  Drivechain-12-0.21.00-x86_64-linux-gnu.tar.gz
+
+Build commit hash (160 bits):
+If the software was developed using git, the build commit hash should match the commit hash of the first sidechain release.
+To verify it later, you can look up this commit in the repository history.
+
+These help users find the sidechain full node software. Only this software can filter out invalid withdrawals.
+                      '''),
+                        // Close butto
+                      ],
+                    ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: IconButton(
+                      icon: const Icon(Icons.close, size: 16),
+                      onPressed: () => Navigator.of(context).pop(),
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ],
+          ),
         );
       },
     );
@@ -197,6 +237,8 @@ class SidechainProposalViewModel extends BaseViewModel {
   final versionController = TextEditingController();
   final tarballHashController = TextEditingController();
   final commitHashController = TextEditingController();
+
+  DrivechainAPI get drivechain => GetIt.I.get<DrivechainAPI>();
 
   String? slotError;
   String? titleError;

--- a/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_proposal_page.dart
@@ -308,6 +308,9 @@ class SidechainProposalViewModel extends BaseViewModel {
     isProposing = true;
     notifyListeners();
 
+    // TODO: Implement the actual API call to propose the sidechain
+    return showSnackBar(context, 'Propose sidechain not implemented');
+    /*
     try {
       // TODO: Implement the actual API call to propose the sidechain
       await Future.delayed(const Duration(seconds: 2)); // Simulating API call
@@ -329,6 +332,7 @@ class SidechainProposalViewModel extends BaseViewModel {
       isProposing = false;
       notifyListeners();
     }
+    */
   }
 
   @override

--- a/packages/drivechain_client/lib/pages/sidechains_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechains_page.dart
@@ -5,6 +5,7 @@ import 'package:drivechain_client/api.dart';
 import 'package:drivechain_client/gen/wallet/v1/wallet.pbgrpc.dart';
 import 'package:drivechain_client/pages/overview_page.dart';
 import 'package:drivechain_client/pages/send_page.dart';
+import 'package:drivechain_client/pages/sidechain_activation_management_page.dart';
 import 'package:drivechain_client/providers/sidechain_provider.dart';
 import 'package:drivechain_client/providers/transactions_provider.dart';
 import 'package:drivechain_client/widgets/error_container.dart';
@@ -85,8 +86,11 @@ class SidechainsList extends ViewModelWidget<SidechainsViewModel> {
             ),
           ),
           const SizedBox(height: SailStyleValues.padding15),
-          const Row(
-            mainAxisAlignment: MainAxisAlignment.center,
+          Center(
+            child: QtButton(
+              child: SailText.primary12('Add / Remove'),
+              onPressed: () => showSidechainActivationManagementModal(context),
+            ),
           ),
         ],
       ),

--- a/packages/drivechain_client/lib/pages/sidechains_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechains_page.dart
@@ -85,18 +85,8 @@ class SidechainsList extends ViewModelWidget<SidechainsViewModel> {
             ),
           ),
           const SizedBox(height: SailStyleValues.padding15),
-          Row(
+          const Row(
             mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Expanded(
-                child: QtButton(
-                  onPressed: () {
-                    showSnackBar(context, 'Not implemented');
-                  },
-                  child: SailText.primary13('Add / Remove'),
-                ),
-              ),
-            ],
           ),
         ],
       ),

--- a/packages/drivechain_client/lib/providers/sidechain_provider.dart
+++ b/packages/drivechain_client/lib/providers/sidechain_provider.dart
@@ -15,6 +15,8 @@ class SidechainProvider extends ChangeNotifier {
   // are actually in use.
   List<Sidechain?> sidechains = List.filled(255, null);
 
+  List<SidechainProposal> sidechainProposals = [];
+
   bool _isFetching = false;
 
   String? error;
@@ -32,6 +34,7 @@ class SidechainProvider extends ChangeNotifier {
 
     try {
       final newSidechains = await api.drivechain.listSidechains();
+      final newSidechainProposals = await api.drivechain.listSidechainProposals();
 
       // Create a new list with 255 slots
       List<Sidechain?> updatedSidechains = List.filled(255, null);
@@ -44,8 +47,9 @@ class SidechainProvider extends ChangeNotifier {
         }
       }
 
-      if (_dataHasChanged(updatedSidechains)) {
+      if (_dataHasChanged(sidechains, updatedSidechains) || _dataHasChanged(sidechainProposals, newSidechainProposals)) {
         sidechains = updatedSidechains;
+        sidechainProposals = newSidechainProposals;
         error = null;
         notifyListeners();
       }
@@ -57,8 +61,8 @@ class SidechainProvider extends ChangeNotifier {
     }
   }
 
-  bool _dataHasChanged(List<Sidechain?> newSidechains) {
-    if (!listEquals(sidechains, newSidechains)) {
+  bool _dataHasChanged<T>(List<T> oldData, List<T> newData) {
+    if (!listEquals(oldData, newData)) {
       return true;
     }
     return false;

--- a/packages/drivechain_client/lib/widgets/qt_button.dart
+++ b/packages/drivechain_client/lib/widgets/qt_button.dart
@@ -29,7 +29,7 @@ class QtButton extends StatelessWidget {
     return SizedBox(
       height: large ? 32 : 24,
       child: SailRawButton(
-        backgroundColor: context.sailTheme.colors.background,
+        backgroundColor: context.sailTheme.colors.backgroundSecondary,
         disabled: !enabled,
         loading: loading,
         onPressed: enabled ? onPressed : null,

--- a/packages/drivechain_client/lib/widgets/qt_button.dart
+++ b/packages/drivechain_client/lib/widgets/qt_button.dart
@@ -29,7 +29,7 @@ class QtButton extends StatelessWidget {
     return SizedBox(
       height: large ? 32 : 24,
       child: SailRawButton(
-        backgroundColor: context.sailTheme.colors.primary.withOpacity(0.5),
+        backgroundColor: context.sailTheme.colors.background,
         disabled: !enabled,
         loading: loading,
         onPressed: enabled ? onPressed : null,

--- a/packages/drivechain_client/lib/widgets/qt_page.dart
+++ b/packages/drivechain_client/lib/widgets/qt_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:sail_ui/sail_ui.dart';
 

--- a/packages/sail_ui/lib/sail_ui.dart
+++ b/packages/sail_ui/lib/sail_ui.dart
@@ -46,6 +46,7 @@ export './widgets/inputs/menu.dart';
 export './widgets/inputs/menu_items.dart';
 export './widgets/inputs/radio_button.dart';
 export './widgets/inputs/text_field.dart';
+export './widgets/inputs/text_form_field.dart';
 export './widgets/loading_indicator.dart';
 export './widgets/nav/nav_components.dart';
 export './widgets/optional_builder.dart';

--- a/packages/sail_ui/lib/sail_ui.dart
+++ b/packages/sail_ui/lib/sail_ui.dart
@@ -21,6 +21,7 @@ export './widgets/components/dashboard_group.dart';
 export './widgets/components/expanded_tx_view.dart';
 export './widgets/components/raw_transaction.dart';
 export './widgets/components/utxo.dart';
+export './widgets/components/table.dart';
 export './widgets/containers/action_tile.dart';
 export './widgets/containers/expandable_list_entry.dart';
 export './widgets/containers/notification.dart';

--- a/packages/sail_ui/lib/widgets/components/table.dart
+++ b/packages/sail_ui/lib/widgets/components/table.dart
@@ -103,146 +103,149 @@ class _SailTableState extends State<SailTable> {
   @override
   Widget build(BuildContext context) {
     final theme = SailTheme.of(context);
-    var themeAltColor = theme.colors.backgroundSecondary;
+    var themeAltColor = theme.colors.background;
     var altBgColor = widget.altBackgroundColor ?? themeAltColor;
 
     var isWindows = context.isWindows;
     var horizontalRowPadding = _horizontalRowPadding(context);
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        double totalColumnSpace = constraints.maxWidth - horizontalRowPadding * 2;
-        bool hasHorizontalOverflow = _totalColumnWidths > totalColumnSpace;
-
-        double extraSpace = 0;
-        if (!hasHorizontalOverflow) {
-          extraSpace = totalColumnSpace - _totalColumnWidths;
-        }
-
-        Widget innerListView;
-
-        if (widget.shrinkWrap) {
-          var children = <Widget>[];
-          for (int i = 0; i < widget.rowCount; i++) {
-            var backgroundColor = i % 2 == 1 ? altBgColor : null;
-            var isLastRow = i == widget.rowCount - 1;
-            children.add(
-              _TableRow(
-                cells: widget.rowBuilder(context, i, _selectedRow == i),
-                widths: _widths,
-                height: widget.cellHeight,
-                selected: _selectedRow == i,
-                backgroundColor: isWindows || widget.drawGrid ? null : backgroundColor,
-                hasHorizontalOverflow: hasHorizontalOverflow,
-                horizontalRowPadding: horizontalRowPadding,
-                grid: widget.drawGrid,
-                extraSpace: extraSpace,
-                drawBorder: (widget.drawLastRowsBorder && isLastRow) || !isLastRow,
-                onPressed: () {
-                  if (widget.selectableRows) {
-                    setState(() {
-                      _selectedRow = i;
-                    });
-                    if (widget.onSelectedRow != null) {
-                      widget.onSelectedRow!(i);
+    return Container(
+      color: theme.colors.backgroundSecondary,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          double totalColumnSpace = constraints.maxWidth - horizontalRowPadding * 2;
+          bool hasHorizontalOverflow = _totalColumnWidths > totalColumnSpace;
+      
+          double extraSpace = 0;
+          if (!hasHorizontalOverflow) {
+            extraSpace = totalColumnSpace - _totalColumnWidths;
+          }
+      
+          Widget innerListView;
+      
+          if (widget.shrinkWrap) {
+            var children = <Widget>[];
+            for (int i = 0; i < widget.rowCount; i++) {
+              var backgroundColor = i % 2 == 1 ? altBgColor : null;
+              var isLastRow = i == widget.rowCount - 1;
+              children.add(
+                _TableRow(
+                  cells: widget.rowBuilder(context, i, _selectedRow == i),
+                  widths: _widths,
+                  height: widget.cellHeight,
+                  selected: _selectedRow == i,
+                  backgroundColor: isWindows || widget.drawGrid ? null : backgroundColor,
+                  hasHorizontalOverflow: hasHorizontalOverflow,
+                  horizontalRowPadding: horizontalRowPadding,
+                  grid: widget.drawGrid,
+                  extraSpace: extraSpace,
+                  drawBorder: (widget.drawLastRowsBorder && isLastRow) || !isLastRow,
+                  onPressed: () {
+                    if (widget.selectableRows) {
+                      setState(() {
+                        _selectedRow = i;
+                      });
+                      if (widget.onSelectedRow != null) {
+                        widget.onSelectedRow!(i);
+                      }
                     }
-                  }
-                },
+                  },
+                ),
+              );
+            }
+      
+            innerListView = Column(
+              mainAxisSize: MainAxisSize.min,
+              children: children,
+            );
+          } else {
+            innerListView = ListView.builder(
+              padding: EdgeInsets.symmetric(
+                vertical: isWindows || widget.drawGrid ? 0 : 6,
               ),
+              shrinkWrap: widget.shrinkWrap,
+              physics: widget.physics,
+              itemCount: widget.rowCount,
+              controller: _verticalController,
+              prototypeItem: SizedBox(
+                width: hasHorizontalOverflow ? _totalColumnWidths + horizontalRowPadding * 2 : constraints.maxWidth,
+                height: widget.cellHeight,
+              ),
+              itemBuilder: (context, row) {
+                var backgroundColor = row % 2 == 1 ? altBgColor : null;
+                var isLastRow = row == widget.rowCount - 1;
+                return _TableRow(
+                  cells: widget.rowBuilder(context, row, false),
+                  widths: _widths,
+                  height: widget.cellHeight,
+                  selected: _selectedRow == row,
+                  backgroundColor: isWindows || widget.drawGrid ? null : backgroundColor,
+                  hasHorizontalOverflow: hasHorizontalOverflow,
+                  horizontalRowPadding: horizontalRowPadding,
+                  grid: widget.drawGrid,
+                  extraSpace: extraSpace,
+                  drawBorder: (widget.drawLastRowsBorder && isLastRow) || !isLastRow,
+                  onPressed: () {
+                    if (widget.selectableRows) {
+                      setState(() {
+                        _selectedRow = row;
+                      });
+                      if (widget.onSelectedRow != null) {
+                        widget.onSelectedRow!(row);
+                      }
+                    }
+                  },
+                );
+              },
             );
           }
-
-          innerListView = Column(
-            mainAxisSize: MainAxisSize.min,
-            children: children,
-          );
-        } else {
-          innerListView = ListView.builder(
-            padding: EdgeInsets.symmetric(
-              vertical: isWindows || widget.drawGrid ? 0 : 6,
-            ),
-            shrinkWrap: widget.shrinkWrap,
-            physics: widget.physics,
-            itemCount: widget.rowCount,
-            controller: _verticalController,
-            prototypeItem: SizedBox(
-              width: hasHorizontalOverflow ? _totalColumnWidths + horizontalRowPadding * 2 : constraints.maxWidth,
-              height: widget.cellHeight,
-            ),
-            itemBuilder: (context, row) {
-              var backgroundColor = row % 2 == 1 ? altBgColor : null;
-              var isLastRow = row == widget.rowCount - 1;
-              return _TableRow(
-                cells: widget.rowBuilder(context, row, false),
-                widths: _widths,
-                height: widget.cellHeight,
-                selected: _selectedRow == row,
-                backgroundColor: isWindows || widget.drawGrid ? null : backgroundColor,
-                hasHorizontalOverflow: hasHorizontalOverflow,
-                horizontalRowPadding: horizontalRowPadding,
-                grid: widget.drawGrid,
-                extraSpace: extraSpace,
-                drawBorder: (widget.drawLastRowsBorder && isLastRow) || !isLastRow,
-                onPressed: () {
-                  if (widget.selectableRows) {
-                    setState(() {
-                      _selectedRow = row;
-                    });
-                    if (widget.onSelectedRow != null) {
-                      widget.onSelectedRow!(row);
-                    }
-                  }
-                },
-              );
-            },
-          );
-        }
-
-        return Scrollbar(
-          controller: _horizontalController,
-          scrollbarOrientation: ScrollbarOrientation.bottom,
-          child: SingleChildScrollView(
+      
+          return Scrollbar(
             controller: _horizontalController,
-            scrollDirection: Axis.horizontal,
-            physics: const ClampingScrollPhysics(),
-            child: SizedBox(
-              width: hasHorizontalOverflow ? _totalColumnWidths + horizontalRowPadding * 2 : constraints.maxWidth,
-              child: Column(
-                children: [
-                  _TableHeader(
-                    widths: _widths,
-                    decoration: widget.headerDecoration ??
-                        BoxDecoration(
-                          border: Border(
-                            bottom: BorderSide(color: theme.colors.divider, width: 1),
+            scrollbarOrientation: ScrollbarOrientation.bottom,
+            child: SingleChildScrollView(
+              controller: _horizontalController,
+              scrollDirection: Axis.horizontal,
+              physics: const ClampingScrollPhysics(),
+              child: SizedBox(
+                width: hasHorizontalOverflow ? _totalColumnWidths + horizontalRowPadding * 2 : constraints.maxWidth,
+                child: Column(
+                  children: [
+                    _TableHeader(
+                      widths: _widths,
+                      decoration: widget.headerDecoration ??
+                          BoxDecoration(
+                            border: Border(
+                              bottom: BorderSide(color: theme.colors.divider, width: 1),
+                            ),
+                            color: theme.colors.background,
                           ),
-                          color: theme.colors.background,
-                        ),
-                    cells: widget.headerBuilder(context),
-                    grid: widget.drawGrid,
-                    resizableColumns: widget.resizableColumns,
-                    horizontalRowPadding: horizontalRowPadding,
-                    extraSpace: extraSpace,
-                    onStartResizeColumn: _onStartResizeColumn,
-                    onEndResizeColumn: _onEndResizeColumn,
-                    onResizedColumn: _onResizedColumn,
-                  ),
-                  if (!widget.shrinkWrap)
-                    Expanded(
-                      child: ScrollConfiguration(
-                        behavior: ScrollConfiguration.of(context).copyWith(
-                          scrollbars: !hasHorizontalOverflow,
-                        ),
-                        child: innerListView,
-                      ),
+                      cells: widget.headerBuilder(context),
+                      grid: widget.drawGrid,
+                      resizableColumns: widget.resizableColumns,
+                      horizontalRowPadding: horizontalRowPadding,
+                      extraSpace: extraSpace,
+                      onStartResizeColumn: _onStartResizeColumn,
+                      onEndResizeColumn: _onEndResizeColumn,
+                      onResizedColumn: _onResizedColumn,
                     ),
-                  if (widget.shrinkWrap) innerListView,
-                ],
+                    if (!widget.shrinkWrap)
+                      Expanded(
+                        child: ScrollConfiguration(
+                          behavior: ScrollConfiguration.of(context).copyWith(
+                            scrollbars: !hasHorizontalOverflow,
+                          ),
+                          child: innerListView,
+                        ),
+                      ),
+                    if (widget.shrinkWrap) innerListView,
+                  ],
+                ),
               ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 

--- a/packages/sail_ui/lib/widgets/components/table.dart
+++ b/packages/sail_ui/lib/widgets/components/table.dart
@@ -475,7 +475,6 @@ class _TableRow extends StatelessWidget {
     required this.horizontalRowPadding,
     required this.drawBorder,
     this.backgroundColor,
-    super.key,
   });
 
   final List<Widget> cells;

--- a/packages/sail_ui/lib/widgets/components/table.dart
+++ b/packages/sail_ui/lib/widgets/components/table.dart
@@ -1,0 +1,655 @@
+import 'package:flutter/material.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+const _headerHeight = 24.0;
+
+class SailTable extends StatefulWidget {
+  const SailTable({
+    required this.headerBuilder,
+    required this.rowBuilder,
+    required this.rowCount,
+    required this.columnCount,
+    required this.columnWidths,
+    this.columnMinWidths,
+    this.columnMaxWidths,
+    this.defaultMinColumnWidth = 50,
+    this.defaultMaxColumnWidth = 200,
+    this.backgroundColor,
+    this.altBackgroundColor,
+    this.headerDecoration,
+    this.selectedRow,
+    this.selectableRows = true,
+    this.onSelectedRow,
+    this.cellHeight = 24.0,
+    this.shrinkWrap = false,
+    this.physics,
+    this.drawGrid = false,
+    this.resizableColumns = true,
+    this.onColumnWidthsChanged,
+    this.drawLastRowsBorder = true,
+    this.onScrollApproachingEnd,
+    super.key,
+  });
+
+  final List<Widget> Function(BuildContext context) headerBuilder;
+  final List<Widget> Function(BuildContext context, int row, bool selected) rowBuilder;
+  final List<double> columnWidths;
+  final List<double>? columnMinWidths;
+  final List<double>? columnMaxWidths;
+  final double defaultMinColumnWidth;
+  final double defaultMaxColumnWidth;
+  final int rowCount;
+  final int columnCount;
+  final Color? backgroundColor;
+  final Color? altBackgroundColor;
+  final BoxDecoration? headerDecoration;
+  final int? selectedRow;
+  final bool selectableRows;
+  final ValueChanged<int?>? onSelectedRow;
+  final double cellHeight;
+  final bool shrinkWrap;
+  final ScrollPhysics? physics;
+  final bool drawGrid;
+  final bool resizableColumns;
+  final bool drawLastRowsBorder;
+  final void Function(List<double> widths)? onColumnWidthsChanged;
+  final VoidCallback? onScrollApproachingEnd;
+
+  @override
+  State<SailTable> createState() => _SailTableState();
+}
+
+class _SailTableState extends State<SailTable> {
+  final ScrollController _horizontalController = ScrollController();
+  final ScrollController _verticalController = ScrollController();
+
+  int? _selectedRow;
+  double get _totalColumnWidths => _widths.fold(0, (prev, e) => prev + e);
+
+  final _widths = <double>[];
+
+  double _horizontalRowPadding(BuildContext context) {
+    return context.isWindows || widget.drawGrid ? 0.0 : 8.0;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedRow = widget.selectedRow;
+    for (var width in widget.columnWidths) {
+      _widths.add(width);
+    }
+
+    _verticalController.addListener(_checkScrollPosition);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _horizontalController.dispose();
+    _verticalController.dispose();
+  }
+
+  void _checkScrollPosition() {
+    if (widget.onScrollApproachingEnd == null) {
+      return;
+    }
+
+    if (_verticalController.position.extentAfter < 100) {
+      widget.onScrollApproachingEnd!();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    var themeAltColor = theme.colors.backgroundSecondary;
+    var altBgColor = widget.altBackgroundColor ?? themeAltColor;
+
+    var isWindows = context.isWindows;
+    var horizontalRowPadding = _horizontalRowPadding(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        double totalColumnSpace = constraints.maxWidth - horizontalRowPadding * 2;
+        bool hasHorizontalOverflow = _totalColumnWidths > totalColumnSpace;
+
+        double extraSpace = 0;
+        if (!hasHorizontalOverflow) {
+          extraSpace = totalColumnSpace - _totalColumnWidths;
+        }
+
+        Widget innerListView;
+
+        if (widget.shrinkWrap) {
+          var children = <Widget>[];
+          for (int i = 0; i < widget.rowCount; i++) {
+            var backgroundColor = i % 2 == 1 ? altBgColor : null;
+            var isLastRow = i == widget.rowCount - 1;
+            children.add(
+              _TableRow(
+                cells: widget.rowBuilder(context, i, _selectedRow == i),
+                widths: _widths,
+                height: widget.cellHeight,
+                selected: _selectedRow == i,
+                backgroundColor: isWindows || widget.drawGrid ? null : backgroundColor,
+                hasHorizontalOverflow: hasHorizontalOverflow,
+                horizontalRowPadding: horizontalRowPadding,
+                grid: widget.drawGrid,
+                extraSpace: extraSpace,
+                drawBorder: (widget.drawLastRowsBorder && isLastRow) || !isLastRow,
+                onPressed: () {
+                  if (widget.selectableRows) {
+                    setState(() {
+                      _selectedRow = i;
+                    });
+                    if (widget.onSelectedRow != null) {
+                      widget.onSelectedRow!(i);
+                    }
+                  }
+                },
+              ),
+            );
+          }
+
+          innerListView = Column(
+            mainAxisSize: MainAxisSize.min,
+            children: children,
+          );
+        } else {
+          innerListView = ListView.builder(
+            padding: EdgeInsets.symmetric(
+              vertical: isWindows || widget.drawGrid ? 0 : 6,
+            ),
+            shrinkWrap: widget.shrinkWrap,
+            physics: widget.physics,
+            itemCount: widget.rowCount,
+            controller: _verticalController,
+            prototypeItem: SizedBox(
+              width: hasHorizontalOverflow ? _totalColumnWidths + horizontalRowPadding * 2 : constraints.maxWidth,
+              height: widget.cellHeight,
+            ),
+            itemBuilder: (context, row) {
+              var backgroundColor = row % 2 == 1 ? altBgColor : null;
+              var isLastRow = row == widget.rowCount - 1;
+              return _TableRow(
+                cells: widget.rowBuilder(context, row, false),
+                widths: _widths,
+                height: widget.cellHeight,
+                selected: _selectedRow == row,
+                backgroundColor: isWindows || widget.drawGrid ? null : backgroundColor,
+                hasHorizontalOverflow: hasHorizontalOverflow,
+                horizontalRowPadding: horizontalRowPadding,
+                grid: widget.drawGrid,
+                extraSpace: extraSpace,
+                drawBorder: (widget.drawLastRowsBorder && isLastRow) || !isLastRow,
+                onPressed: () {
+                  if (widget.selectableRows) {
+                    setState(() {
+                      _selectedRow = row;
+                    });
+                    if (widget.onSelectedRow != null) {
+                      widget.onSelectedRow!(row);
+                    }
+                  }
+                },
+              );
+            },
+          );
+        }
+
+        return Scrollbar(
+          controller: _horizontalController,
+          scrollbarOrientation: ScrollbarOrientation.bottom,
+          child: SingleChildScrollView(
+            controller: _horizontalController,
+            scrollDirection: Axis.horizontal,
+            physics: const ClampingScrollPhysics(),
+            child: SizedBox(
+              width: hasHorizontalOverflow ? _totalColumnWidths + horizontalRowPadding * 2 : constraints.maxWidth,
+              child: Column(
+                children: [
+                  _TableHeader(
+                    widths: _widths,
+                    decoration: widget.headerDecoration ??
+                        BoxDecoration(
+                          border: Border(
+                            bottom: BorderSide(color: theme.colors.divider, width: 1),
+                          ),
+                          color: theme.colors.background,
+                        ),
+                    cells: widget.headerBuilder(context),
+                    grid: widget.drawGrid,
+                    resizableColumns: widget.resizableColumns,
+                    horizontalRowPadding: horizontalRowPadding,
+                    extraSpace: extraSpace,
+                    onStartResizeColumn: _onStartResizeColumn,
+                    onEndResizeColumn: _onEndResizeColumn,
+                    onResizedColumn: _onResizedColumn,
+                  ),
+                  if (!widget.shrinkWrap)
+                    Expanded(
+                      child: ScrollConfiguration(
+                        behavior: ScrollConfiguration.of(context).copyWith(
+                          scrollbars: !hasHorizontalOverflow,
+                        ),
+                        child: innerListView,
+                      ),
+                    ),
+                  if (widget.shrinkWrap) innerListView,
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant SailTable oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _checkScrollPosition();
+    });
+  }
+
+  double _startColumnWidth = 0;
+
+  void _onStartResizeColumn(int column) {
+    _startColumnWidth = _widths[column];
+  }
+
+  void _onEndResizeColumn(int column) {
+    if (widget.onColumnWidthsChanged != null) {
+      widget.onColumnWidthsChanged!(_widths);
+    }
+  }
+
+  void _onResizedColumn(int column, double delta) {
+    if (!widget.resizableColumns) {
+      return;
+    }
+
+    var minWidth = widget.columnMinWidths?.elementAt(column) ?? widget.defaultMinColumnWidth;
+    var maxWidth = widget.columnMaxWidths?.elementAt(column) ?? widget.defaultMaxColumnWidth;
+
+    setState(() {
+      var width = _startColumnWidth + delta;
+      if (width < minWidth) {
+        width = minWidth;
+      } else if (width > maxWidth) {
+        width = maxWidth;
+      }
+      _widths[column] = width;
+    });
+  }
+}
+
+class _TableHeader extends StatelessWidget {
+  const _TableHeader({
+    required this.cells,
+    required this.widths,
+    required this.decoration,
+    required this.grid,
+    required this.resizableColumns,
+    required this.extraSpace,
+    required this.onResizedColumn,
+    required this.onStartResizeColumn,
+    required this.onEndResizeColumn,
+    required this.horizontalRowPadding,
+  });
+
+  final List<Widget> cells;
+  final List<double> widths;
+  final BoxDecoration? decoration;
+  final bool grid;
+  final bool resizableColumns;
+  final double extraSpace;
+  final double horizontalRowPadding;
+  final void Function(int column, double delta) onResizedColumn;
+  final void Function(int column) onStartResizeColumn;
+  final void Function(int column) onEndResizeColumn;
+
+  @override
+  Widget build(BuildContext context) {
+    _TableColumnResizeHandleStyle handleStyle;
+    if (grid) {
+      handleStyle = _TableColumnResizeHandleStyle.full;
+    } else if (!resizableColumns) {
+      handleStyle = _TableColumnResizeHandleStyle.none;
+    } else if (context.isWindows) {
+      handleStyle = _TableColumnResizeHandleStyle.full;
+    } else {
+      handleStyle = _TableColumnResizeHandleStyle.partial;
+    }
+
+    var cellWidgets = <Widget>[];
+    int i = 0;
+    for (var cell in cells) {
+      var index = i;
+      var width = widths[i];
+      if (i == 0) {
+        width -= _TableColumnResizeHandle._width / 2;
+      } else {
+        width -= _TableColumnResizeHandle._width;
+      }
+
+      cellWidgets.add(
+        SizedBox(
+          width: width,
+          child: DefaultTextStyle(
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: SailStyleValues.ten,
+            child: cell,
+          ),
+        ),
+      );
+
+      cellWidgets.add(
+        _TableColumnResizeHandle(
+          style: handleStyle,
+          last: i == cells.length - 1,
+          onDragStart: () {
+            onStartResizeColumn(index);
+          },
+          onDragEnd: () {
+            onEndResizeColumn(index);
+          },
+          onDragUpdate: (delta) {
+            onResizedColumn(index, delta);
+          },
+        ),
+      );
+
+      i += 1;
+    }
+
+    return Container(
+      decoration: decoration ??
+          BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: context.sailTheme.colors.divider,
+                width: 1.0,
+              ),
+            ),
+            color: context.sailTheme.colors.background,
+          ),
+      height: _headerHeight,
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontalRowPadding,
+      ),
+      child: Row(
+        children: cellWidgets,
+      ),
+    );
+  }
+}
+
+enum _TableColumnResizeHandleStyle {
+  none,
+  full,
+  partial,
+}
+
+class _TableColumnResizeHandle extends StatefulWidget {
+  const _TableColumnResizeHandle({
+    required this.onDragUpdate,
+    required this.onDragStart,
+    required this.onDragEnd,
+    required this.last,
+    required this.style,
+  });
+
+  final ValueChanged<double> onDragUpdate;
+  final VoidCallback onDragStart;
+  final VoidCallback onDragEnd;
+  final bool last;
+  final _TableColumnResizeHandleStyle style;
+
+  static const _width = 8.0;
+
+  @override
+  _TableColumnResizeHandleState createState() => _TableColumnResizeHandleState();
+}
+
+class _TableColumnResizeHandleState extends State<_TableColumnResizeHandle> {
+  double _downX = 0.0;
+
+  @override
+  Widget build(BuildContext context) {
+    var verticalGap = widget.style == _TableColumnResizeHandleStyle.partial ? 2.0 : 0.0;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeLeftRight,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: (details) {
+          _downX = details.globalPosition.dx;
+          widget.onDragStart();
+        },
+        onHorizontalDragEnd: (details) {
+          widget.onDragEnd();
+        },
+        onHorizontalDragUpdate: (details) {
+          var globalDelta = details.globalPosition.dx - _downX;
+          widget.onDragUpdate(globalDelta);
+        },
+        child: SizedBox(
+          width: widget.last ? _TableColumnResizeHandle._width / 2 : _TableColumnResizeHandle._width,
+          child: Container(
+            margin: EdgeInsets.only(
+              left: _TableColumnResizeHandle._width / 2 - 1,
+              top: verticalGap,
+              bottom: verticalGap,
+            ),
+            decoration: BoxDecoration(
+              border: widget.style == _TableColumnResizeHandleStyle.none
+                  ? null
+                  : Border(
+                      left: BorderSide(
+                        color: context.sailTheme.colors.divider,
+                        width: 1.0,
+                      ),
+                    ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TableRow extends StatelessWidget {
+  const _TableRow({
+    required this.cells,
+    required this.onPressed,
+    required this.selected,
+    required this.hasHorizontalOverflow,
+    required this.widths,
+    required this.height,
+    required this.grid,
+    required this.extraSpace,
+    required this.horizontalRowPadding,
+    required this.drawBorder,
+    this.backgroundColor,
+    super.key,
+  });
+
+  final List<Widget> cells;
+  final VoidCallback onPressed;
+  final bool selected;
+  final bool hasHorizontalOverflow;
+  final Color? backgroundColor;
+  final List<double> widths;
+  final double height;
+  final bool grid;
+  final double extraSpace;
+  final double horizontalRowPadding;
+  final bool drawBorder;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    var isWindows = context.isWindows;
+
+    var cellWidgets = <Widget>[];
+    int i = 0;
+    for (var cell in cells) {
+      cellWidgets.add(
+        Container(
+          decoration: grid
+              ? BoxDecoration(
+                  border: Border(
+                    right: BorderSide(
+                      color: theme.colors.divider,
+                      width: 1.0,
+                    ),
+                  ),
+                )
+              : null,
+          width: widths[i],
+          height: height,
+          child: DefaultTextStyle(
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: selected ? Colors.white : null,
+            ),
+            child: cell,
+          ),
+        ),
+      );
+      i += 1;
+    }
+
+    if (extraSpace > 0) {
+      cellWidgets.add(
+        SizedBox(
+          width: extraSpace,
+          height: height,
+        ),
+      );
+    }
+
+    Widget contents;
+
+    if (isWindows || grid) {
+      contents = Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: horizontalRowPadding,
+        ),
+        decoration: BoxDecoration(
+          color: selected ? theme.colors.primary : backgroundColor,
+          border: drawBorder
+              ? Border(
+                  bottom: BorderSide(
+                    color: theme.colors.divider,
+                    width: 1.0,
+                  ),
+                )
+              : null,
+        ),
+        child: Row(
+          children: cellWidgets,
+        ),
+      );
+    } else {
+      contents = Container(
+        margin: EdgeInsets.symmetric(
+          horizontal: hasHorizontalOverflow ? 0.0 : horizontalRowPadding,
+        ),
+        padding: EdgeInsets.symmetric(
+          horizontal: hasHorizontalOverflow ? horizontalRowPadding : 0.0,
+        ),
+        decoration: BoxDecoration(
+          borderRadius:
+              hasHorizontalOverflow ? null : const BorderRadius.all(Radius.circular(SailStyleValues.padding05)),
+          color: selected ? theme.colors.primary : backgroundColor,
+        ),
+        child: Row(
+          children: cellWidgets,
+        ),
+      );
+    }
+
+    return GestureDetector(
+      onTap: onPressed,
+      behavior: HitTestBehavior.opaque,
+      child: contents,
+    );
+  }
+}
+
+class SailTableCell extends StatelessWidget {
+  const SailTableCell({
+    required this.child,
+    this.alignment = Alignment.centerLeft,
+    this.padding = const EdgeInsets.symmetric(horizontal: 8),
+    this.plainIconTheme,
+    this.selectedIconTheme,
+    super.key,
+  });
+
+  final Widget child;
+  final Alignment alignment;
+  final EdgeInsets padding;
+  final IconThemeData? plainIconTheme;
+  final IconThemeData? selectedIconTheme;
+
+  @override
+  Widget build(BuildContext context) {
+    var tableRow = context.findAncestorWidgetOfExactType<_TableRow>();
+    assert(
+      tableRow != null,
+      'Table cell needs to be a child of SailTable',
+    );
+
+    final theme = SailTheme.of(context);
+    IconThemeData iconTheme;
+    if (tableRow!.selected) {
+      iconTheme = selectedIconTheme ??
+          IconThemeData(
+            color: theme.colors.iconHighlighted,
+          );
+    } else {
+      iconTheme = plainIconTheme ??
+          IconThemeData(
+            color: theme.colors.icon,
+          );
+    }
+
+    return Container(
+      alignment: alignment,
+      padding: padding,
+      child: IconTheme(
+        data: iconTheme,
+        child: child,
+      ),
+    );
+  }
+}
+
+class SailTableHeaderCell extends StatelessWidget {
+  const SailTableHeaderCell({
+    required this.child,
+    this.alignment = Alignment.centerLeft,
+    this.padding = const EdgeInsets.symmetric(horizontal: 8),
+    super.key,
+  });
+
+  final Widget child;
+  final Alignment alignment;
+  final EdgeInsets padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: alignment,
+      padding: padding,
+      child: child,
+    );
+  }
+}

--- a/packages/sail_ui/lib/widgets/inputs/text_field.dart
+++ b/packages/sail_ui/lib/widgets/inputs/text_field.dart
@@ -23,7 +23,7 @@ class SailTextField extends StatelessWidget {
   final bool readOnly;
   final bool dense;
   final bool enabled;
-
+  final int? maxLines;
   const SailTextField({
     super.key,
     required this.controller,
@@ -42,6 +42,7 @@ class SailTextField extends StatelessWidget {
     this.readOnly = false,
     this.dense = false,
     this.enabled = true,
+    this.maxLines,
   });
 
   @override
@@ -84,6 +85,7 @@ class SailTextField extends StatelessWidget {
             if (textFieldType == TextFieldType.number) FilteringTextInputFormatter.allow(RegExp(r'^\d+$')),
             if (textFieldType == TextFieldType.bitcoin) FilteringTextInputFormatter.allow(RegExp(r'^\d+\.?\d{0,8}')),
           ],
+          maxLines: maxLines,
           decoration: InputDecoration(
             errorBorder: InputBorder.none,
             disabledBorder: InputBorder.none,

--- a/packages/sail_ui/lib/widgets/inputs/text_form_field.dart
+++ b/packages/sail_ui/lib/widgets/inputs/text_form_field.dart
@@ -64,7 +64,7 @@ class SailTextFormField extends StatelessWidget {
             padding: const EdgeInsets.only(
               left: 2,
             ),
-            child: SailText.secondary13(label!),
+            child: SailText.primary12(label!),
           ),
         TextFormField(
            enabled: enabled,
@@ -75,8 +75,16 @@ class SailTextFormField extends StatelessWidget {
           focusNode: focusNode,
           readOnly: readOnly,
           decoration: InputDecoration(
-            errorBorder: InputBorder.none,
+            errorBorder: OutlineInputBorder(
+              borderRadius: const BorderRadius.all(Radius.circular(6)),
+              borderSide: BorderSide(color: theme.colors.error),
+            ),
             disabledBorder: InputBorder.none,
+            focusedErrorBorder:  OutlineInputBorder(
+              
+              borderRadius: const BorderRadius.all(Radius.circular(6)),
+              borderSide: BorderSide(color: theme.colors.error),
+            ),
             enabledBorder: OutlineInputBorder(
               borderRadius: const BorderRadius.all(Radius.circular(6)),
               borderSide: BorderSide(color: theme.colors.formFieldBorder),

--- a/packages/sail_ui/lib/widgets/inputs/text_form_field.dart
+++ b/packages/sail_ui/lib/widgets/inputs/text_form_field.dart
@@ -11,6 +11,16 @@ class SailTextFormField extends StatelessWidget {
   final String? Function(String?)? validator;
   final void Function(String)? onChanged;
   final int? maxLines;
+  final TextFieldSize? size;
+  final bool enabled;
+  final FocusNode? focusNode;
+  final String? suffix;
+  final Widget? suffixWidget;
+  final String? prefix;
+  final Widget? prefixWidget;
+  final Widget? prefixIcon;
+  final BoxConstraints? prefixIconConstraints;
+
   const SailTextFormField({
     super.key,
     this.controller,
@@ -22,48 +32,89 @@ class SailTextFormField extends StatelessWidget {
     this.validator,
     this.onChanged,
     this.maxLines,
+    this.size,
+    this.enabled = true,
+    this.focusNode,
+    this.suffix,
+    this.suffixWidget,
+    this.prefix,
+    this.prefixWidget,
+    this.prefixIcon,
+    this.prefixIconConstraints,
   });
 
   @override
   Widget build(BuildContext context) {
+    final theme = SailTheme.of(context);
+    final padding = size != TextFieldSize.regular
+        ? EdgeInsets.all(
+            theme.dense ? SailStyleValues.padding08 : SailStyleValues.padding15,
+          )
+        : EdgeInsets.symmetric(
+            vertical: theme.dense ? SailStyleValues.padding05 : SailStyleValues.padding10,
+            horizontal: theme.dense ? SailStyleValues.padding10 : SailStyleValues.padding15,
+          );
+    final textSize = size == TextFieldSize.regular ? 15.0 : 12.0;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (label != null) 
+        if (label != null)
           Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: SailText.primary13(label!),
+            padding: const EdgeInsets.only(
+              left: 2,
+            ),
+            child: SailText.secondary13(label!),
           ),
         TextFormField(
+           enabled: enabled,
+          mouseCursor: enabled ? WidgetStateMouseCursor.textable : SystemMouseCursors.forbidden,
+          cursorColor: theme.colors.primary,
+          cursorHeight: textSize,
           controller: controller,
+          focusNode: focusNode,
+          readOnly: readOnly,
           decoration: InputDecoration(
-            hintText: hintText,
-            errorText: errorText,
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(4),
-              borderSide: BorderSide(color: context.sailTheme.colors.formFieldBorder),
-            ),
+            errorBorder: InputBorder.none,
+            disabledBorder: InputBorder.none,
             enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(4),
-              borderSide: BorderSide(color: context.sailTheme.colors.formFieldBorder),
+              borderRadius: const BorderRadius.all(Radius.circular(6)),
+              borderSide: BorderSide(color: theme.colors.formFieldBorder),
             ),
             focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(4),
-              borderSide: BorderSide(color: context.sailTheme.colors.primary),
+              borderRadius: const BorderRadius.all(Radius.circular(6)),
+              borderSide: BorderSide(color: theme.colors.formFieldBorder),
             ),
-            errorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(4),
-              borderSide: BorderSide(color: context.sailTheme.colors.error),
+            suffixStyle: TextStyle(
+              color: SailTheme.of(context).colors.textTertiary,
+              fontSize: textSize,
             ),
-            focusedErrorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(4),
-              borderSide: BorderSide(color: context.sailTheme.colors.error),
+            suffixText: suffix,
+            suffix: suffixWidget == null
+                ? null
+                : Padding(
+                    padding: const EdgeInsets.only(left: SailStyleValues.padding08),
+                    child: suffixWidget,
+                  ),
+            prefixStyle: TextStyle(
+              color: SailTheme.of(context).colors.textTertiary,
+              fontSize: textSize,
             ),
+            prefixText: prefix,
+            prefix: prefixWidget,
+            prefixIcon: prefixIcon,
+            prefixIconConstraints: prefixIconConstraints,
+            fillColor: SailTheme.of(context).colors.backgroundSecondary,
             filled: true,
-            fillColor: context.sailTheme.colors.formField,
+            contentPadding: padding,
+            isDense: theme.dense,
+            hintText: hintText,
+            hintStyle: TextStyle(
+              color: SailTheme.of(context).colors.textTertiary,
+              fontSize: textSize,
+            ),
           ),
           style: SailStyleValues.thirteen,
-          readOnly: readOnly,
           keyboardType: keyboardType,
           validator: validator,
           onChanged: onChanged,

--- a/packages/sail_ui/lib/widgets/inputs/text_form_field.dart
+++ b/packages/sail_ui/lib/widgets/inputs/text_form_field.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:sail_ui/sail_ui.dart';
+
+class SailTextFormField extends StatelessWidget {
+  final TextEditingController? controller;
+  final String? label;
+  final String? hintText;
+  final String? errorText;
+  final bool readOnly;
+  final TextInputType? keyboardType;
+  final String? Function(String?)? validator;
+  final void Function(String)? onChanged;
+  final int? maxLines;
+  const SailTextFormField({
+    super.key,
+    this.controller,
+    this.label,
+    this.hintText,
+    this.errorText,
+    this.readOnly = false,
+    this.keyboardType,
+    this.validator,
+    this.onChanged,
+    this.maxLines,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (label != null) 
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: SailText.primary13(label!),
+          ),
+        TextFormField(
+          controller: controller,
+          decoration: InputDecoration(
+            hintText: hintText,
+            errorText: errorText,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(4),
+              borderSide: BorderSide(color: context.sailTheme.colors.formFieldBorder),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(4),
+              borderSide: BorderSide(color: context.sailTheme.colors.formFieldBorder),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(4),
+              borderSide: BorderSide(color: context.sailTheme.colors.primary),
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(4),
+              borderSide: BorderSide(color: context.sailTheme.colors.error),
+            ),
+            focusedErrorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(4),
+              borderSide: BorderSide(color: context.sailTheme.colors.error),
+            ),
+            filled: true,
+            fillColor: context.sailTheme.colors.formField,
+          ),
+          style: SailStyleValues.thirteen,
+          readOnly: readOnly,
+          keyboardType: keyboardType,
+          validator: validator,
+          onChanged: onChanged,
+          maxLines: maxLines,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Currently implemented as a dialog as multi-window support is lacking, though it has some downsides that _can_ be mitigated if need be.

Also introduces new sail_ui components; `SailTable` and `SailTextFormField`.

Note: this does not implement the RPC calls to ack, nack and create a sidechain proposal as those are not available yet. The placeholders will need to be updated when these RPCs land. 