### PR TITLE
drivechain-server: (nit) output executables to `/bin` folder

### DIFF
--- a/drivechain-server/.gitignore
+++ b/drivechain-server/.gitignore
@@ -3,3 +3,4 @@ drivechain-server
 /bdk/.crates*
 /enforcer/bin/
 /enforcer/.crates*
+/*.mdb

--- a/drivechain-server/Justfile
+++ b/drivechain-server/Justfile
@@ -1,5 +1,5 @@
 build-go:
-    go build -o drivechain-server .
+    go build -o ./bin/drivechain-server .
 
 build: build-bdk-cli build-enforcer build-go
 

--- a/drivechain-server/README.md
+++ b/drivechain-server/README.md
@@ -40,7 +40,7 @@ $ ./enforcer/bin/bip300301_enforcer \
 #
 # The same Electrum server also powers the mempool instance
 # at https://drivechain.ngu-tek.no.
-$ ./drivechain-server \
+$ ./bin/drivechain-server \
   --electrum.host=drivechain.live:50001 \
   --electrum.no-ssl \
   --bitcoincore.rpcuser=user \


### PR DESCRIPTION
Convention I guess, just nitpicking. Also adds .mdb folders to .gitignore. Just close if too silly. 