### PR TITLE
drivechain_client: replace `DataTable` with `SailTable`, add header sorting

### DIFF
--- a/packages/drivechain_client/lib/pages/overview_page.dart
+++ b/packages/drivechain_client/lib/pages/overview_page.dart
@@ -391,6 +391,7 @@ class _LatestTransactionTableState extends State<LatestTransactionTable> {
   @override
   Widget build(BuildContext context) {
     return SailTable(
+      getRowId: (index) => entries[index].txid,
       headerBuilder: (context) => [
         SailTableHeaderCell(
           child: SailText.primary12('Time'),
@@ -504,6 +505,7 @@ class _LatestBlocksTableState extends State<LatestBlocksTable> {
   @override
   Widget build(BuildContext context) {
     return SailTable(
+      getRowId: (index) => blocks[index].hash,
       headerBuilder: (context) => [
         SailTableHeaderCell(child: SailText.primary12('Time')),
         SailTableHeaderCell(child: SailText.primary12('Height')),

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/annotations.dart';
 import 'package:drivechain_client/widgets/qt_icon_button.dart';
 import 'package:drivechain_client/widgets/qt_page.dart';
 import 'package:drivechain_client/widgets/qt_button.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:sail_ui/sail_ui.dart';
 import 'package:stacked/stacked.dart';
@@ -78,33 +79,7 @@ class SidechainActivationManagementView extends StatelessWidget {
               borderRadius: BorderRadius.circular(4.0),
             ),
             height: 150,
-            
-            child: SailTable(
-              headerBuilder: (context) => [
-                SailTableHeaderCell(child: SailText.primary12('#')),
-                SailTableHeaderCell(child: SailText.primary12('Active')),
-                SailTableHeaderCell(child: SailText.primary12('Name')),
-                SailTableHeaderCell(child: SailText.primary12('CTIP TxID')),
-                //TODO: SailTableHeaderCell(child: SailText.primary12('CTIP Index')),
-              ],
-              rowBuilder: (context, row, selected) {
-                // TODO: Revise the data, it's not yet clear what is what. The columns is taken straight from
-                // drivechain-qt and might not be available in the API.
-                final sidechain = model.activeSidechains[row];
-                return [
-                  SailTableCell(child: SailText.primary12('${sidechain.slot}')),
-                  SailTableCell(child: SailText.primary12('Yes')),
-                  SailTableCell(child: SailText.primary12(sidechain.title)),
-                  SailTableCell(
-                    child: SailText.primary12(sidechain.chaintipTxid.isEmpty ? 'N/A' : sidechain.chaintipTxid),
-                  ),
-                  //TODO: SailTableCell(child: SailText.primary12('TODO')),
-                ];
-              },
-              rowCount: model.activeSidechains.length,
-              columnCount: 4, // TODO: 5
-              columnWidths: const [50, 100, 100, 500],
-            ),
+            child: ActiveSidechainsTable(blocks: model.activeSidechains),
           ),
           const SizedBox(height: SailStyleValues.padding15),
           SailText.primary12('Pending Sidechain Proposals'),
@@ -120,36 +95,7 @@ class SidechainActivationManagementView extends StatelessWidget {
               borderRadius: BorderRadius.circular(4.0),
             ),
             height: 150,
-            child: SailTable(
-              headerBuilder: (context) => [
-                SailTableHeaderCell(child: SailText.primary12('Vote')),
-                SailTableHeaderCell(child: SailText.primary12('SC #')),
-                SailTableHeaderCell(child: SailText.primary12('Replacement')),
-                SailTableHeaderCell(child: SailText.primary12('Title')),
-                SailTableHeaderCell(child: SailText.primary12('Description')),
-                SailTableHeaderCell(child: SailText.primary12('Age')),
-                SailTableHeaderCell(child: SailText.primary12('Fails')),
-                SailTableHeaderCell(child: SailText.primary12('Hash')),
-              ],
-              rowBuilder: (context, row, selected) {
-                final proposal = model.sidechainProposals[row];
-                // TODO: Revise the data, it's not yet clear what is what. The columns is taken straight from
-                // drivechain-qt and might not be available in the API.
-                return [
-                  SailTableCell(child: SailText.primary12(proposal.voteCount.toString())),
-                  SailTableCell(child: SailText.primary12(proposal.slot.toString())),
-                  SailTableCell(child: SailText.primary12('Replacement')),
-                  SailTableCell(child: SailText.primary12(proposal.data.toString())),
-                  SailTableCell(child: SailText.primary12('Description')),
-                  SailTableCell(child: SailText.primary12(proposal.proposalAge.toString())),
-                  SailTableCell(child: SailText.primary12(proposal.proposalHeight.toString())),
-                  SailTableCell(child: SailText.primary12(proposal.dataHash)),
-                ];
-              },
-              rowCount: model.sidechainProposals.length,
-              columnCount: 8,
-              columnWidths: const [50, 50, 100, 100, 200, 50, 50, 200],
-            ),
+            child: PendingSidechainProposalsTable(proposals: model.sidechainProposals),
           ),
           const SizedBox(height: SailStyleValues.padding30),
           Row(
@@ -194,6 +140,110 @@ class SidechainActivationManagementView extends StatelessWidget {
   }
 }
 
+class ActiveSidechainsTable extends StatefulWidget {
+  final List<ListSidechainsResponse_Sidechain> blocks;
+
+  const ActiveSidechainsTable({
+    super.key,
+    required this.blocks,
+  });
+
+  @override
+  State<ActiveSidechainsTable> createState() => _ActiveSidechainsTableState();
+}
+
+class _ActiveSidechainsTableState extends State<ActiveSidechainsTable> {
+  String sortColumn = 'slot';
+  bool sortAscending = true;
+  List<ListSidechainsResponse_Sidechain> blocks = [];
+
+  @override
+  void initState() {
+    super.initState();
+    blocks = widget.blocks;
+    sortBlocks();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!listEquals(blocks, widget.blocks)) {
+      blocks = widget.blocks;
+      sortBlocks();
+    }
+  }
+
+  void onSort(String column) {
+    if (column == sortColumn) {
+      sortAscending = !sortAscending;
+    } else {
+      sortColumn = column;
+      sortAscending = true;
+    }
+    sortBlocks();
+    setState(() {});
+  }
+
+  void sortBlocks() {
+    blocks.sort((a, b) {
+      dynamic aValue = '';
+      dynamic bValue = '';
+
+      switch (sortColumn) {
+        case 'slot':
+          aValue = a.slot;
+          bValue = b.slot;
+          break;
+        case 'name':
+          aValue = a.title;
+          bValue = b.title;
+          break;
+        case 'chaintipTxid':
+          aValue = a.chaintipTxid;
+          bValue = b.chaintipTxid;
+          break;
+      }
+
+      return sortAscending ? aValue.compareTo(bValue) : bValue.compareTo(aValue);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SailTable(
+      headerBuilder: (context) => [
+        SailTableHeaderCell(child: SailText.primary12('#')),
+        SailTableHeaderCell(child: SailText.primary12('Active')),
+        SailTableHeaderCell(child: SailText.primary12('Name')),
+        SailTableHeaderCell(child: SailText.primary12('CTIP TxID')),
+        //TODO: SailTableHeaderCell(child: SailText.primary12('CTIP Index')),
+      ],
+      rowBuilder: (context, row, selected) {
+        // TODO: Revise the data, it's not yet clear what is what. The columns is taken straight from
+        // drivechain-qt and might not be available in the API.
+        final sidechain = blocks[row];
+        return [
+          SailTableCell(child: SailText.primary12('${sidechain.slot}')),
+          SailTableCell(child: SailText.primary12('Yes')),
+          SailTableCell(child: SailText.primary12(sidechain.title)),
+          SailTableCell(
+            child: SailText.primary12(sidechain.chaintipTxid.isEmpty ? 'N/A' : sidechain.chaintipTxid),
+          ),
+          //TODO: SailTableCell(child: SailText.primary12('TODO')),
+        ];
+      },
+      rowCount: blocks.length,
+      columnCount: 4, // TODO: 5
+      columnWidths: const [50, 100, 100, 500],
+      sortColumnIndex: ['slot', 'active', 'name', 'chaintipTxid'].indexOf(sortColumn),
+      sortAscending: sortAscending,
+      onSort: (columnIndex, ascending) {
+        onSort(['slot', 'active', 'name', 'chaintipTxid'][columnIndex]);
+      },
+    );
+  }
+}
+
 Future<void> showSidechainActivationManagementModal(BuildContext context) {
   return showAdaptiveDialog<void>(
     barrierDismissible: true,
@@ -211,4 +261,132 @@ Future<void> showSidechainActivationManagementModal(BuildContext context) {
       );
     },
   );
+}
+
+class PendingSidechainProposalsTable extends StatefulWidget {
+  final List<SidechainProposal> proposals;
+
+  const PendingSidechainProposalsTable({
+    super.key,
+    required this.proposals,
+  });
+
+  @override
+  State<PendingSidechainProposalsTable> createState() => _PendingSidechainProposalsTableState();
+}
+
+class _PendingSidechainProposalsTableState extends State<PendingSidechainProposalsTable> {
+  String sortColumn = 'slot';
+  bool sortAscending = true;
+  List<SidechainProposal> proposals = [];
+
+  @override
+  void initState() {
+    super.initState();
+    proposals = widget.proposals;
+    sortProposals();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!listEquals(proposals, widget.proposals)) {
+      proposals = widget.proposals;
+      sortProposals();
+    }
+  }
+
+  void onSort(String column) {
+    if (column == sortColumn) {
+      sortAscending = !sortAscending;
+    } else {
+      sortColumn = column;
+      sortAscending = true;
+    }
+    sortProposals();
+    setState(() {});
+  }
+
+  void sortProposals() {
+    proposals.sort((a, b) {
+      dynamic aValue = '';
+      dynamic bValue = '';
+
+      switch (sortColumn) {
+        case 'slot':
+          aValue = a.slot;
+          bValue = b.slot;
+          break;
+        case 'voteCount':
+          aValue = a.voteCount;
+          bValue = b.voteCount;
+          break;
+        /*case 'replacement':
+          aValue = a.replacement;
+          bValue = b.replacement;
+          break;*/
+        /*case 'title':
+          aValue = a.title;
+          bValue = b.title;
+          break;*/
+        /*case 'description':
+          aValue = a.description;
+          bValue = b.description;
+          break;*/
+        case 'age':
+          aValue = a.proposalAge;
+          bValue = b.proposalAge;
+          break;
+        case 'fails':
+          aValue = a.proposalHeight;
+          bValue = b.proposalHeight;
+          break;
+        case 'hash':
+          aValue = a.dataHash;
+          bValue = b.dataHash;
+          break;
+      }
+
+      return sortAscending ? aValue.compareTo(bValue) : bValue.compareTo(aValue);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SailTable(
+      headerBuilder: (context) => [
+        SailTableHeaderCell(child: SailText.primary12('Vote')),
+        SailTableHeaderCell(child: SailText.primary12('SC #')),
+        SailTableHeaderCell(child: SailText.primary12('Replacement')),
+        SailTableHeaderCell(child: SailText.primary12('Title')),
+        SailTableHeaderCell(child: SailText.primary12('Description')),
+        SailTableHeaderCell(child: SailText.primary12('Age')),
+        SailTableHeaderCell(child: SailText.primary12('Fails')),
+        SailTableHeaderCell(child: SailText.primary12('Hash')),
+      ],
+      rowBuilder: (context, row, selected) {
+        final proposal = widget.proposals[row];
+        // TODO: Revise the data, it's not yet clear what is what. The columns is taken straight from
+        // drivechain-qt and might not be available in the API.
+        return [
+          SailTableCell(child: SailText.primary12(proposal.voteCount.toString())),
+          SailTableCell(child: SailText.primary12(proposal.slot.toString())),
+          SailTableCell(child: SailText.primary12('Replacement')),
+          SailTableCell(child: SailText.primary12(proposal.data.toString())),
+          SailTableCell(child: SailText.primary12('Description')),
+          SailTableCell(child: SailText.primary12(proposal.proposalAge.toString())),
+          SailTableCell(child: SailText.primary12(proposal.proposalHeight.toString())),
+          SailTableCell(child: SailText.primary12(proposal.dataHash)),
+        ];
+      },
+      rowCount: widget.proposals.length,
+      columnCount: 8,
+      columnWidths: const [50, 50, 100, 100, 200, 50, 50, 200],
+      sortColumnIndex: ['voteCount', 'slot', 'age', 'fails', 'hash'].indexOf(sortColumn),
+      sortAscending: sortAscending,
+      onSort: (columnIndex, ascending) {
+        onSort(['voteCount', 'slot', 'age', 'fails', 'hash'][columnIndex]);
+      },
+    );
+  }
 }

--- a/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechain_activation_management_page.dart
@@ -211,6 +211,7 @@ class _ActiveSidechainsTableState extends State<ActiveSidechainsTable> {
   @override
   Widget build(BuildContext context) {
     return SailTable(
+      getRowId: (index) => blocks[index].slot.toString(),
       headerBuilder: (context) => [
         SailTableHeaderCell(child: SailText.primary12('#')),
         SailTableHeaderCell(child: SailText.primary12('Active')),
@@ -354,6 +355,7 @@ class _PendingSidechainProposalsTableState extends State<PendingSidechainProposa
   @override
   Widget build(BuildContext context) {
     return SailTable(
+      getRowId: (index) => widget.proposals[index].slot.toString(),
       headerBuilder: (context) => [
         SailTableHeaderCell(child: SailText.primary12('Vote')),
         SailTableHeaderCell(child: SailText.primary12('SC #')),

--- a/packages/drivechain_client/lib/pages/sidechains_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechains_page.dart
@@ -371,55 +371,31 @@ class RecentDepositsTable extends ViewModelWidget<SidechainsViewModel> {
   Widget build(BuildContext context, SidechainsViewModel viewModel) {
     return QtContainer(
       tight: true,
-      child: SingleChildScrollView(
-        scrollDirection: Axis.vertical,
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: DataTable(
-            decoration: BoxDecoration(
-              color: context.sailTheme.colors.backgroundSecondary,
-              border: Border.all(
-                color: context.sailTheme.colors.formFieldBorder,
-                width: 1.0,
-              ),
-            ),
-            border: TableBorder.symmetric(
-              inside: BorderSide(
-                color: context.sailTheme.colors.formFieldBorder,
-                width: 1.0,
-              ),
-            ),
-            headingRowColor: WidgetStateProperty.all(
-              context.sailTheme.colors.formFieldBorder,
-            ),
-            columnSpacing: SailStyleValues.padding15,
-            headingRowHeight: 24.0,
-            dataTextStyle: SailStyleValues.twelve,
-            headingTextStyle: SailStyleValues.ten,
-            dividerThickness: 0,
-            dataRowMaxHeight: 48.0,
-            columns: [
-              DataColumn(label: SailText.primary12('SC #')),
-              DataColumn(label: SailText.primary12('Amount')),
-              DataColumn(label: SailText.primary12('Txid')),
-              DataColumn(label: SailText.primary12('Address')),
-              DataColumn(label: SailText.primary12('Visible on SC?')),
-            ],
-            rows: deposits
-                .map(
-                  (deposit) => DataRow(
-                    cells: [
-                      DataCell(SailText.primary12(viewModel._selectedIndex.toString())),
-                      DataCell(SailText.primary12(deposit.amount.toString())),
-                      DataCell(SailText.primary12(deposit.txid.toString())),
-                      DataCell(SailText.primary12(deposit.address)),
-                      DataCell(SailText.primary12(deposit.confirmations >= 2 ? 'Yes' : 'No')),
-                    ],
-                  ),
-                )
-                .toList(),
-          ),
+      child: SailTable(
+        headerBuilder: (context) => [
+          SailTableHeaderCell(child: SailText.primary12('SC #')),
+          SailTableHeaderCell(child: SailText.primary12('Amount')),
+          SailTableHeaderCell(child: SailText.primary12('Txid')),
+          SailTableHeaderCell(child: SailText.primary12('Address')),
+          SailTableHeaderCell(child: SailText.primary12('Visible on SC?')),
+        ],
+        rowBuilder: (context, row, selected) {
+          final deposit = deposits[row];
+          return [
+            SailTableCell(child: SailText.primary12(viewModel._selectedIndex.toString())),
+            SailTableCell(child: SailText.primary12(deposit.amount.toString())),
+            SailTableCell(child: SailText.primary12(deposit.txid.toString())),
+            SailTableCell(child: SailText.primary12(deposit.address)),
+            SailTableCell(child: SailText.primary12(deposit.confirmations >= 2 ? 'Yes' : 'No')),
+          ];
+        },
+        rowCount: deposits.length,
+        columnCount: 5,
+        columnWidths: const [50, 100, 200, 200, 100],
+        headerDecoration: BoxDecoration(
+          color: context.sailTheme.colors.formFieldBorder,
         ),
+        drawGrid: true,
       ),
     );
   }

--- a/packages/drivechain_client/lib/pages/sidechains_page.dart
+++ b/packages/drivechain_client/lib/pages/sidechains_page.dart
@@ -372,6 +372,7 @@ class RecentDepositsTable extends ViewModelWidget<SidechainsViewModel> {
     return QtContainer(
       tight: true,
       child: SailTable(
+        getRowId: (index) => deposits[index].txid,
         headerBuilder: (context) => [
           SailTableHeaderCell(child: SailText.primary12('SC #')),
           SailTableHeaderCell(child: SailText.primary12('Amount')),

--- a/packages/drivechain_client/lib/pages/transactions_page.dart
+++ b/packages/drivechain_client/lib/pages/transactions_page.dart
@@ -44,7 +44,6 @@ class TransactionTable extends StatefulWidget {
   const TransactionTable({
     super.key,
     required this.entries,
-
   });
 
   @override
@@ -65,7 +64,7 @@ class _TransactionTableState extends State<TransactionTable> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if(!listEquals(entries, widget.entries)) {
+    if (!listEquals(entries, widget.entries)) {
       entries = widget.entries;
       onSort(sortColumn);
     }
@@ -86,7 +85,7 @@ class _TransactionTableState extends State<TransactionTable> {
     entries.sort((a, b) {
       dynamic aValue = '';
       dynamic bValue = '';
-      
+
       switch (sortColumn) {
         case 'conf':
           aValue = a.confirmationTime.height;
@@ -105,7 +104,7 @@ class _TransactionTableState extends State<TransactionTable> {
           bValue = b.receivedSatoshi;
           break;
       }
-      
+
       return sortAscending ? aValue.compareTo(bValue) : bValue.compareTo(aValue);
     });
   }
@@ -113,6 +112,7 @@ class _TransactionTableState extends State<TransactionTable> {
   @override
   Widget build(BuildContext context) {
     return SailTable(
+      getRowId: (index) => widget.entries[index].txid,
       headerBuilder: (context) => [
         SailTableHeaderCell(
           child: SailText.primary12('Conf'),
@@ -162,6 +162,7 @@ class AddressMenuViewModel extends BaseViewModel {
       .where(
         (tx) => searchController.text.isEmpty || tx.txid.contains(searchController.text),
       )
+      // if empty, mock some data
       .toList();
 
   String sortColumn = 'conf';

--- a/packages/sail_ui/lib/widgets/components/table.dart
+++ b/packages/sail_ui/lib/widgets/components/table.dart
@@ -220,13 +220,27 @@ class _SailTableState extends State<SailTable> {
           }
 
           // Update the header builder to include sort indicators and functionality
-          List<Widget> header = widget.headerBuilder(context);
-          for (int i = 0; i < header.length; i++) {
-            header[i] = GestureDetector(
+          List<Widget> header = widget.headerBuilder(context).asMap().entries.map((entry) {
+            int i = entry.key;
+            Widget headerCell = entry.value;
+            
+            if (headerCell is SailTableHeaderCell) {
+              return SailTableHeaderCell(
+                alignment: headerCell.alignment,
+                padding: headerCell.padding,
+                isSorted: _sortColumnIndex == i,
+                isAscending: _sortAscending,
+                onSort: () => _sort(i, _sortColumnIndex != i || !_sortAscending),
+                child: headerCell.child,
+              );
+            }
+            
+            return GestureDetector(
+              behavior: HitTestBehavior.opaque,
               onTap: () => _sort(i, _sortColumnIndex != i || !_sortAscending),
-              child: header[i],
+              child: headerCell,
             );
-          }
+          }).toList();
 
           return Scrollbar(
             controller: _horizontalController,
@@ -668,6 +682,8 @@ class SailTableHeaderCell extends StatelessWidget {
     this.alignment = Alignment.centerLeft,
     this.padding = const EdgeInsets.symmetric(horizontal: 8),
     this.onSort,
+    this.isSorted = false,
+    this.isAscending = true,
     super.key,
   });
 
@@ -675,15 +691,30 @@ class SailTableHeaderCell extends StatelessWidget {
   final Alignment alignment;
   final EdgeInsets padding;
   final VoidCallback? onSort;
+  final bool isSorted;
+  final bool isAscending;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onSort,
+      behavior: HitTestBehavior.opaque,
       child: Container(
         alignment: alignment,
         padding: padding,
-        child: child,
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Flexible(child: child),
+            if (isSorted)
+              Icon(
+                isAscending ? Icons.arrow_upward : Icons.arrow_downward,
+                size: 13,
+                color: SailTheme.of(context).colors.icon,
+              ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
The tables have turned; we're now using `SailTable` everywhere in order to get a uniform look/feel. This change also adds sorting to all tables, hence refactoring simple `DataTable`/`SailTable` subtrees into their own widgets in order to control the sorting state.

This change introduces sorting functionality to `SailTable` very similar to the `DataTable` API.